### PR TITLE
chore: gitignore .npmrc (prevent committing npm auth tokens)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 .env
 .env.local
 .avito-token.json
+.npmrc
 
 # Local MCP config (contains absolute paths, use .mcp.json.example as template)
 .mcp.json


### PR DESCRIPTION
Adds `.npmrc` to `.gitignore`. `npm config set` can write the npm auth token into a project-level `.npmrc`; this ensures such a file (a secret) can never be accidentally committed. No code/version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)