### PR TITLE
Enforce full credentials before using cached Avito tokens (prevent introspection-mode bypass)

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -170,6 +170,7 @@ export class AvitoClient {
     };
 
     if (opts.auth !== false) {
+      this.assertCredentialsConfigured();
       const token = await this.tokenStore.getToken();
       headers.Authorization = `Bearer ${token}`;
     }
@@ -200,6 +201,12 @@ export class AvitoClient {
     throw new Error(`Unsupported bodyContentType: ${contentType}`);
   }
 
+  private assertCredentialsConfigured(): void {
+    if (!this.config.clientId || !this.config.clientSecret || this.config.profileId === undefined) {
+      throw new MissingCredentialsError();
+    }
+  }
+
   /**
    * OAuth 2.0 client_credentials. The same handler backs the POST /token endpoint.
    * Done without an auth token (we don't have one yet), directly via fetch.
@@ -208,12 +215,10 @@ export class AvitoClient {
     accessToken: string;
     expiresIn: number;
   }> {
-    // v0.7.4: lazy credential enforcement. tools/list works without creds; the first
-    // tool call that needs a token lands here. If creds are absent, fail with a clear
-    // CONFIG_ERROR instead of POSTing empty client_id/secret to Avito.
-    if (!this.config.clientId || !this.config.clientSecret) {
-      throw new MissingCredentialsError();
-    }
+    // Defense-in-depth: buildHeadersAndBody() already checks this before reading any
+    // cached token, but keep the guard here so direct token refreshes and future callers
+    // cannot POST partial credentials to Avito.
+    this.assertCredentialsConfigured();
     const url = `${this.config.baseUrl.replace(/\/+$/, '')}/token`;
     const params = new URLSearchParams({
       grant_type: 'client_credentials',

--- a/test/no-credentials.test.ts
+++ b/test/no-credentials.test.ts
@@ -23,7 +23,7 @@ import { domains } from '../src/meta/domain-registry.js';
 import type { Config } from '../src/config.js';
 
 /** Config with NO credentials — clientId/clientSecret empty, profileId undefined. */
-function makeUnconfiguredConfig(): Config {
+function makeUnconfiguredConfig(overrides: Partial<Config> = {}): Config {
   return {
     clientId: '',
     clientSecret: '',
@@ -61,6 +61,7 @@ function makeUnconfiguredConfig(): Config {
       path: '/avito/webhook',
       bufferSize: 100,
     },
+    ...overrides,
   };
 }
 
@@ -128,6 +129,47 @@ describe('introspection without credentials', () => {
       error: { type: 'CONFIG_ERROR', retryable: false },
     });
     // Must NOT have attempted any network call (not even /token).
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('calling a tool without credentials ignores a valid cached token and returns CONFIG_ERROR', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const cfg = makeUnconfiguredConfig();
+    await fs.writeFile(
+      cfg.tokenFile,
+      JSON.stringify({
+        accessToken: 'CACHED-TOKEN-SHOULD-NOT-BE-USED-WITHOUT-CREDS',
+        expiresAt: Date.now() + 3_600_000,
+      }),
+    );
+    const { client } = await makeRig(cfg);
+    cleanup = async () => {
+      await client.close();
+      await fs.rm(cfg.tokenFile, { force: true });
+    };
+    const res = await client.callTool({ name: 'user_get_user_info_self', arguments: {} });
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent).toMatchObject({
+      error: { type: 'CONFIG_ERROR', retryable: false },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('calling a tool with client credentials but no profile id returns CONFIG_ERROR before token fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const cfg = makeUnconfiguredConfig({ clientId: 'client-id', clientSecret: 'client-secret' });
+    const { client } = await makeRig(cfg);
+    cleanup = async () => {
+      await client.close();
+      await fs.rm(cfg.tokenFile, { force: true });
+    };
+    const res = await client.callTool({ name: 'user_get_user_info_self', arguments: {} });
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent).toMatchObject({
+      error: { type: 'CONFIG_ERROR', retryable: false },
+    });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
### Motivation
- Introspection-only startup allowed the server to read an on-disk or in-memory cached access token and make authenticated Avito calls even when credentials were not fully configured, which breaks the advertised safety boundary. 
- The previous lazy check ran only during token fetch and validated only `clientId`/`clientSecret`, allowing both cached-token reuse and the case where `profileId` was missing but other creds existed. 
- The change aims to prevent accidental or malicious reuse of previously persisted tokens and ensure the server truly runs in read-only introspection mode until all three credentials are present. 

### Description
- Added `assertCredentialsConfigured()` to `AvitoClient` that requires `clientId`, `clientSecret`, and `profileId` to be present. 
- Enforced the credential guard before any authenticated request reads a token by calling the guard in `buildHeadersAndBody()` prior to `tokenStore.getToken()`. 
- Reused the same guard in `fetchTokenViaClientCredentials()` as a defense-in-depth measure to avoid posting partial credentials to the token endpoint. 
- Extended `test/no-credentials.test.ts` (made `makeUnconfiguredConfig` accept overrides) with two regression tests that assert a valid cached token is ignored when credentials are absent and that having client creds but no `profileId` is rejected before any token fetch. 

### Testing
- Ran the targeted tests with `npm test -- --run test/no-credentials.test.ts`, and the modified tests passed. 
- Performed full verification: `npm run typecheck`, `npm run build`, `npm run generate:manifest`, `npm test`, and `npm run lint`, and the final full test run passed (all tests succeeded after generating the manifest). 
- Lint and typecheck completed successfully and the build/manifest generation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33cc80b3ec83248b19882e6bb9216e)