### PR TITLE
Fix idempotency race for destructive tools

### DIFF
--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -27,6 +27,12 @@ export interface IdempotencyEntry {
   result: CallToolResult;
 }
 
+interface IdempotencyReservation {
+  argsHash: string;
+  expiresAt: number;
+  promise: Promise<IdempotencyEntry>;
+}
+
 export class IdempotencyConflictError extends Error {
   constructor(key: string, toolName: string) {
     super(
@@ -39,6 +45,7 @@ export class IdempotencyConflictError extends Error {
 
 export class IdempotencyStore {
   private entries = new Map<string, IdempotencyEntry>();
+  private reservations = new Map<string, IdempotencyReservation>();
 
   constructor(private readonly ttlMs: number) {}
 
@@ -77,7 +84,52 @@ export class IdempotencyStore {
       result,
     };
     this.entries.set(this.composeKey(toolName, key), entry);
+    this.reservations.delete(this.composeKey(toolName, key));
     return entry;
+  }
+
+  /**
+   * Atomically runs the operation for a new (toolName, key), or waits for the
+   * already in-flight operation with the same args. This closes the lookup →
+   * execute → remember race for concurrent destructive calls in one process.
+   */
+  async runExclusive(
+    key: string,
+    toolName: string,
+    argsHash: string,
+    execute: () => Promise<CallToolResult>,
+  ): Promise<{ entry: IdempotencyEntry; replay: boolean }> {
+    const composed = this.composeKey(toolName, key);
+    this.cleanupExpired();
+
+    const cached = this.entries.get(composed);
+    if (cached) {
+      if (cached.argsHash !== argsHash) throw new IdempotencyConflictError(key, toolName);
+      return { entry: cached, replay: true };
+    }
+
+    const existing = this.reservations.get(composed);
+    if (existing) {
+      if (existing.argsHash !== argsHash) throw new IdempotencyConflictError(key, toolName);
+      return { entry: await existing.promise, replay: true };
+    }
+
+    const now = Date.now();
+    const promise = (async () => {
+      try {
+        const result = await execute();
+        return this.remember(key, toolName, argsHash, result);
+      } catch (err) {
+        this.reservations.delete(composed);
+        throw err;
+      }
+    })();
+    this.reservations.set(composed, {
+      argsHash,
+      expiresAt: now + this.ttlMs,
+      promise,
+    });
+    return { entry: await promise, replay: false };
   }
 
   size(): number {
@@ -99,6 +151,9 @@ export class IdempotencyStore {
     const now = Date.now();
     for (const [k, e] of this.entries) {
       if (e.expiresAt < now) this.entries.delete(k);
+    }
+    for (const [k, r] of this.reservations) {
+      if (r.expiresAt < now) this.reservations.delete(k);
     }
   }
 }

--- a/src/core/tool-factory.ts
+++ b/src/core/tool-factory.ts
@@ -272,7 +272,7 @@ export function defineTool<I extends ZodRawShape>(
     // we check (toolName, key, hash(args)).
     //   - hit + matching args → return the cache marked idempotent_replay=true
     //   - hit + different args → return a structured error (conflict)
-    //   - miss → execute, then remember
+    //   - miss → reserve atomically before executing/creating a pending action
     const idempotencyKey =
       destructive && typeof args.idempotencyKey === 'string' && args.idempotencyKey.length > 0
         ? args.idempotencyKey
@@ -311,7 +311,7 @@ export function defineTool<I extends ZodRawShape>(
           return r;
         },
       });
-      return {
+      const pendingResult: CallToolResult = {
         content: [
           {
             type: 'text',
@@ -341,13 +341,29 @@ export function defineTool<I extends ZodRawShape>(
           expires_at: new Date(pending.expiresAt).toISOString(),
         },
       };
+      if (idempotencyKey && ctx.idempotencyStore && argsHash) {
+        ctx.idempotencyStore.remember(idempotencyKey, spec.name, argsHash, pendingResult);
+      }
+      return pendingResult;
     }
 
-    const result = await execute(cleanArgs);
     if (idempotencyKey && ctx.idempotencyStore && argsHash) {
-      ctx.idempotencyStore.remember(idempotencyKey, spec.name, argsHash, result);
+      try {
+        const { entry, replay } = await ctx.idempotencyStore.runExclusive(
+          idempotencyKey,
+          spec.name,
+          argsHash,
+          () => execute(cleanArgs),
+        );
+        return replay ? annotateReplay(entry.result) : entry.result;
+      } catch (err) {
+        if (err instanceof IdempotencyConflictError) {
+          return errorToMcpContent(err);
+        }
+        throw err;
+      }
     }
-    return result;
+    return execute(cleanArgs);
   };
 
   // The SDK types the callback via an internal BaseToolCallback with its own inferred CallToolResult,

--- a/test/confirmation.test.ts
+++ b/test/confirmation.test.ts
@@ -21,6 +21,7 @@ import { promises as fs } from 'node:fs';
 
 import { AvitoClient } from '../src/core/client.js';
 import { defineTool, type ToolContext } from '../src/core/tool-factory.js';
+import { IdempotencyStore } from '../src/core/idempotency.js';
 import { PendingActionStore } from '../src/core/pending-actions.js';
 import { register as registerMeta } from '../src/domains/meta.js';
 import type { Config, ConfirmationMode } from '../src/config.js';
@@ -91,7 +92,8 @@ async function makeRig(
     retry: { retry429BaseMs: 1, max429Retries: 0, retry5xxBackoffMs: 1, max5xxRetries: 0 },
   });
   const pendingStore = new PendingActionStore(cfg.confirmationTtlSec * 1000);
-  const ctx: ToolContext = { client, config: cfg, pendingStore };
+  const idempotencyStore = new IdempotencyStore(cfg.idempotencyTtlSec * 1000);
+  const ctx: ToolContext = { client, config: cfg, pendingStore, idempotencyStore };
 
   const server = new McpServer({ name: 'test', version: '0.0.0' });
   // Register one tool per risk and the meta confirmation tools.
@@ -169,6 +171,29 @@ describe('confirmation flow', () => {
     expect(payload.risk).toBe('money');
     expect(rig.fetchMock).not.toHaveBeenCalled();
     expect(rig.pendingStore.size()).toBe(1);
+    await rig.client.close();
+  });
+
+  it('reuses the same pending action for duplicate idempotency keys before confirmation', async () => {
+    const rig = await makeRig('money_public');
+    cfg = rig.cfg;
+    const args = { item_id: 1, vas_id: 'highlight', idempotencyKey: 'same-confirm-key' };
+    const first = await rig.client.callTool({ name: 'money_tool', arguments: args });
+    const second = await rig.client.callTool({ name: 'money_tool', arguments: args });
+    const firstId = extractConfirmationId(parseText(first.content));
+    const secondId = extractConfirmationId(parseText(second.content));
+
+    expect(secondId).toBe(firstId);
+    expect(rig.pendingStore.size()).toBe(1);
+    expect(rig.fetchMock).not.toHaveBeenCalled();
+
+    const confirmed = await rig.client.callTool({
+      name: 'meta_confirm_action',
+      arguments: { confirmation_id: firstId },
+    });
+    expect(confirmed.isError).not.toBe(true);
+    expect(rig.fetchMock.mock.calls.length).toBeGreaterThan(0);
+    expect(rig.pendingStore.size()).toBe(0);
     await rig.client.close();
   });
 

--- a/test/idempotency.test.ts
+++ b/test/idempotency.test.ts
@@ -70,4 +70,33 @@ describe('idempotency', () => {
     expect(list[0]).toMatchObject({ key: 'k', toolName: 't' });
     expect((list[0] as unknown as { result?: unknown }).result).toBeUndefined();
   });
+
+  it('runExclusive coalesces concurrent calls with the same key and args', async () => {
+    const store = new IdempotencyStore(60_000);
+    const h = hashArgs({ a: 1 });
+    let executions = 0;
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const first = store.runExclusive('k', 't', h, async () => {
+      executions += 1;
+      await barrier;
+      return resultOf('done');
+    });
+    const second = store.runExclusive('k', 't', h, async () => {
+      executions += 1;
+      return resultOf('duplicate');
+    });
+
+    expect(executions).toBe(1);
+    release();
+    const [a, b] = await Promise.all([first, second]);
+    expect(executions).toBe(1);
+    expect(a.replay).toBe(false);
+    expect(b.replay).toBe(true);
+    expect((a.entry.result.content[0] as { text: string }).text).toBe('done');
+    expect((b.entry.result.content[0] as { text: string }).text).toBe('done');
+  });
 });


### PR DESCRIPTION
### Motivation
- The idempotency ledger previously performed separate `lookup` and `remember` operations, leaving a race window where concurrent destructive calls or duplicate pre-confirmation requests with the same `idempotencyKey` could execute multiple times.
- Pending confirmation closures recorded the idempotency entry only after execution, allowing multiple pending actions with the same key to be created and later confirmed independently.

### Description
- Add an in-flight reservation path to `IdempotencyStore` by introducing `reservations` and a new `runExclusive` method that either returns a cached entry, waits for an in-flight execution, or reserves+executes atomically to avoid lookup→execute→remember races (`src/core/idempotency.ts`).
- Update destructive tool handling in `defineTool` to use `runExclusive` for non-confirmed destructive calls so concurrent calls with the same `(toolName, idempotencyKey, argsHash)` coalesce into a single execution and subsequent callers receive a replayed result (`src/core/tool-factory.ts`).
- Persist the pending confirmation response into the idempotency ledger immediately when creating a pending action so repeated pre-confirmation calls with the same `idempotencyKey` return the same confirmation payload instead of creating duplicate pending actions (`src/core/tool-factory.ts`).
- Add regression tests that verify coalescing of concurrent executions and reuse of the same pending action for duplicate idempotency keys before confirmation (`test/idempotency.test.ts`, `test/confirmation.test.ts`).

### Testing
- Ran lint with `npm run lint` and the code passed after a small fix to prefer `const` over `let` in a local change (passed).
- Type-check succeeded with `tsc --noEmit` (passed).
- Ran targeted unit tests with `vitest` for the modified areas via `npm test -- --run test/idempotency.test.ts test/confirmation.test.ts` and all targeted tests passed (27 tests in those files passed).
- Full test run `npm test` fails in the environment due to a missing generated artifact (`dist/manifest.json`) required by `test/manifest-snapshot.test.ts`; this is unrelated to the idempotency changes and is documented by the suite as requiring `npm run generate:manifest` before running the full suite in local CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33ce6cda4483249edf6e865f8ae17b)