### PR TITLE
Restrict messenger_register_webhook URL overrides to configured receiver

### DIFF
--- a/src/domains/webhook.ts
+++ b/src/domains/webhook.ts
@@ -234,15 +234,15 @@ export const register: DomainRegister = (server, ctx) => {
 
   // Subscribes Avito to the configured receiver URL. Reuses the generic confirmation /
   // dry-run / idempotency machinery via defineTool. The default URL is computed from the
-  // webhook config; the agent may override it explicitly.
+  // webhook config; caller input may repeat that URL but must not redirect events elsewhere.
   defineTool(server, ctx, {
     name: 'messenger_register_webhook',
     title: '⚠️ Register webhook receiver',
     risk: 'write',
     description:
       'Subscribes Avito to THIS server\'s configured webhook receiver URL so messenger events (new chat messages) start flowing. ' +
-      'By default it registers the URL derived from the webhook config (AVITO_MCP_WEBHOOK_PUBLIC_URL + path + secret); ' +
-      'pass `url` to override. Adds a webhook subscription (additive — it does not delete other subscriptions); Avito will then ' +
+      'Registers only the URL derived from the webhook config (AVITO_MCP_WEBHOOK_PUBLIC_URL + path + secret). ' +
+      'Adds a webhook subscription (additive — it does not delete other subscriptions); Avito will then ' +
       'POST events to the URL (requires a PUBLIC HTTPS address reachable from the internet; localhost does not work). ' +
       'Same operation as messenger_post_webhook_v3, but auto-fills the URL from config. ' +
       'Pairs with messenger_get_webhook_events (read received events) and messenger_get_webhook_status (receiver config). ' +
@@ -256,28 +256,34 @@ export const register: DomainRegister = (server, ctx) => {
         .url()
         .optional()
         .describe(
-          'Optional override of the public HTTPS URL Avito should POST events to. ' +
-            'Omit to use the configured receiver URL (publicUrl + path + secret).',
+          'Optional explicit copy of the configured receiver URL Avito should POST events to. ' +
+            'For safety, it must equal publicUrl + path + secret; omit to auto-fill it.',
         ),
     },
     body: {
       contentType: 'application/json',
-      // Note: `url` is intentionally NOT pinned via `fields` so a user-supplied `url`
-      // input overrides the computed default (splitArgs merges { ...defaults, ...body }).
-      // defaults() must not throw on an unconfigured receiver — it runs even when the
-      // caller passes an explicit `url`; the requirement is enforced in transform(),
-      // which sees the merged body.
+      // The registration endpoint changes where Avito will send future messenger events.
+      // Never allow a caller-provided URL to redirect those events to an arbitrary host;
+      // it may only repeat the operator-configured receiver URL.
       defaults: (c) => {
         const w = c.config.webhook;
-        if (!w.enabled || !w.secret) return {};
+        if (!w.enabled || !w.secret) {
+          throw new Error(
+            'Webhook receiver is not configured: set AVITO_MCP_WEBHOOK_SECRET (and ' +
+              'AVITO_MCP_WEBHOOK_PUBLIC_URL for a public domain).',
+          );
+        }
         return { url: `${w.publicUrl}${w.path}/${w.secret}` };
       },
       transform: (body) => {
+        const expectedUrl = `${ctx.config.webhook.publicUrl}${ctx.config.webhook.path}/${ctx.config.webhook.secret}`;
         const url = typeof body.url === 'string' ? body.url : undefined;
         if (!url) {
+          throw new Error('Webhook receiver URL could not be computed from config.');
+        }
+        if (url !== expectedUrl) {
           throw new Error(
-            'Webhook receiver is not configured: set AVITO_MCP_WEBHOOK_SECRET (and ' +
-              'AVITO_MCP_WEBHOOK_PUBLIC_URL for a public domain), or pass `url` explicitly.',
+            'Webhook URL override must match the configured receiver URL; arbitrary webhook destinations are not allowed.',
           );
         }
         assertAvitoReachableUrl(url);

--- a/test/webhook-tools.test.ts
+++ b/test/webhook-tools.test.ts
@@ -291,8 +291,7 @@ describe('messenger_register_webhook (v0.9.1 hardening)', () => {
     expect(text).toContain('not reachable from Avito');
   });
 
-  it('explicit url override works even when the receiver is NOT configured', async () => {
-    // Pre-0.9.1 this threw 'not configured' BEFORE the override was even merged.
+  it('rejects explicit url override when the receiver is NOT configured', async () => {
     const rig = await makeRig({
       webhook: makeWebhookConfig({ enabled: false, secret: undefined }),
     });
@@ -305,9 +304,40 @@ describe('messenger_register_webhook (v0.9.1 hardening)', () => {
       name: 'messenger_register_webhook',
       arguments: { dryRun: true, url: 'https://hooks.example.com/avito-events' },
     });
+    const text = JSON.stringify(r.content) + JSON.stringify(r.structuredContent ?? {});
+    expect(text).toContain('not configured');
+  });
+
+  it('rejects arbitrary explicit url overrides even when the receiver is configured', async () => {
+    const rig = await makeRig();
+    cleanup = async () => {
+      await rig.client.close();
+      await fs.rm(rig.cfg.tokenFile, { force: true });
+    };
+
+    const r = await rig.client.callTool({
+      name: 'messenger_register_webhook',
+      arguments: { dryRun: true, url: 'https://hooks.example.com/avito-events' },
+    });
+    const text = JSON.stringify(r.content) + JSON.stringify(r.structuredContent ?? {});
+    expect(text).toContain('arbitrary webhook destinations are not allowed');
+  });
+
+  it('accepts an explicit url only when it matches the configured receiver', async () => {
+    const rig = await makeRig();
+    cleanup = async () => {
+      await rig.client.close();
+      await fs.rm(rig.cfg.tokenFile, { force: true });
+    };
+
+    const expectedUrl = `https://mcp.example.com/avito/webhook/${WEBHOOK_SECRET}`;
+    const r = await rig.client.callTool({
+      name: 'messenger_register_webhook',
+      arguments: { dryRun: true, url: expectedUrl },
+    });
     expect(r.isError).not.toBe(true);
     const payload = parseStructured<Preview>(r as { structuredContent?: unknown });
-    expect(payload.request_preview.body.url).toBe('https://hooks.example.com/avito-events');
+    expect(payload.request_preview.body.url).toBe(expectedUrl);
   });
 
   it('errors clearly when unconfigured and no url is given', async () => {


### PR DESCRIPTION
### Motivation
- Prevent callers from registering arbitrary public HTTPS webhook endpoints (an exfiltration sink) by ensuring webhook registration cannot redirect Avito events to attacker-controlled hosts.
- Restore a clear configuration failure when the local webhook receiver is disabled or missing its secret so an explicit `url` cannot bypass operator configuration.

### Description
- Change `messenger_register_webhook` semantics so the tool registers only the operator-configured receiver URL (`publicUrl + path + secret`) and an explicit `url` is accepted only when it exactly matches that configured value.
- Make `defaults` throw when `webhook.enabled` or `webhook.secret` are missing so registration fails fast on misconfiguration instead of accepting arbitrary overrides.
- Update the tool `description` and `input` schema to require that any explicit `url` be an explicit copy of the configured receiver URL for safety.
- Add and modify tests in `test/webhook-tools.test.ts` to cover rejection of unconfigured overrides, rejection of arbitrary overrides, and acceptance only when the explicit URL equals the configured receiver URL.

### Testing
- Ran the focused webhook tests with `npm test -- --run test/webhook-tools.test.ts`, which passed.
- Ran the TypeScript typecheck with `npm run typecheck`, which succeeded.
- Built and generated the manifest then ran the full test suite with `npm run build && npm run generate:manifest && npm test`, which resulted in all tests passing (202 passed, 0 failed).
- Ran linting with `npm run lint`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33c73ea9308324a795fbad0ca528c6)