### PR TITLE
fix: gate pending actions resource by policy

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -30,6 +30,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { logger } from './logger.js';
+import { evaluatePolicy } from './core/policy.js';
 import type { ToolContext } from './core/tool-factory.js';
 import { PACKAGE_NAME, VERSION } from './version.js';
 
@@ -142,6 +143,7 @@ function safeReadFile(p: string): string | null {
 }
 
 export function registerResources(server: McpServer, ctx: ToolContext): void {
+  const pendingActionsDecision = evaluatePolicy('meta_list_pending_actions', 'read', ctx.config);
   // ─────────── avito://docs/safety ───────────
   server.registerResource(
     'safety-docs',
@@ -237,36 +239,48 @@ export function registerResources(server: McpServer, ctx: ToolContext): void {
   );
 
   // ─────────── avito://state/pending-actions ───────────
-  // subscribable: when the pending-store changes, the server sends resources/updated.
-  server.registerResource(
-    'pending-actions',
-    PENDING_ACTIONS_URI,
-    {
-      title: 'Pending actions (live)',
-      description:
-        'Pending actions currently awaiting confirmation. Subscribable: a client can ' +
-        'subscribe via resources/subscribe and receive notifications/resources/updated ' +
-        'on every create/confirm/cancel/expire.',
-      mimeType: 'application/json',
-    },
-    async (uri): Promise<ReadResourceResult> => {
-      const items = ctx.pendingStore.list();
-      return jsonResource(uri.toString(), {
-        count: items.length,
-        confirmation_mode: ctx.config.confirmationMode,
-        confirmation_ttl_sec: ctx.config.confirmationTtlSec,
-        hard_confirmation: !!ctx.config.confirmationSecret,
-        pending: items.map((a) => ({
-          id: a.id,
-          tool: a.toolName,
-          risk: a.risk,
-          summary: a.summary,
-          created_at: new Date(a.createdAt).toISOString(),
-          expires_at: new Date(a.expiresAt).toISOString(),
-        })),
-      });
-    },
-  );
+  // Mirrors meta_list_pending_actions and must obey the same allow/deny policy,
+  // because it exposes the same bearer-like confirmation ids.
+  if (pendingActionsDecision.allowed) {
+    server.registerResource(
+      'pending-actions',
+      PENDING_ACTIONS_URI,
+      {
+        title: 'Pending actions (live)',
+        description:
+          'Pending actions currently awaiting confirmation. Subscribable: a client can ' +
+          'subscribe via resources/subscribe and receive notifications/resources/updated ' +
+          'on every create/confirm/cancel/expire.',
+        mimeType: 'application/json',
+      },
+      async (uri): Promise<ReadResourceResult> => {
+        const items = ctx.pendingStore.list();
+        return jsonResource(uri.toString(), {
+          count: items.length,
+          confirmation_mode: ctx.config.confirmationMode,
+          confirmation_ttl_sec: ctx.config.confirmationTtlSec,
+          hard_confirmation: !!ctx.config.confirmationSecret,
+          pending: items.map((a) => ({
+            id: a.id,
+            tool: a.toolName,
+            risk: a.risk,
+            summary: a.summary,
+            created_at: new Date(a.createdAt).toISOString(),
+            expires_at: new Date(a.expiresAt).toISOString(),
+          })),
+        });
+      },
+    );
+  } else {
+    logger.info(
+      {
+        resource: PENDING_ACTIONS_URI,
+        tool: 'meta_list_pending_actions',
+        reason: pendingActionsDecision.reason,
+      },
+      'resource hidden by policy',
+    );
+  }
 
   // ─────────── avito://webhook/events ───────────
   // v0.9.0: subscribable, like pending-actions. Emits resources/updated on every
@@ -300,6 +314,7 @@ export function registerResources(server: McpServer, ctx: ToolContext): void {
   // it lightly: track a set of subscribers and, on a pending-actions change, notify only them.
   const subscribers = new Set<string>();
   server.server.setRequestHandler(SubscribeRequestSchema, async (req) => {
+    if (req.params.uri === PENDING_ACTIONS_URI && !pendingActionsDecision.allowed) return {};
     subscribers.add(req.params.uri);
     return {};
   });

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -71,8 +71,9 @@ function makeConfig(): Config {
   };
 }
 
-async function makeRig() {
+async function makeRig(configure: (cfg: Config) => void = () => {}) {
   const cfg = makeConfig();
+  configure(cfg);
   const pendingStore = new PendingActionStore(cfg.confirmationTtlSec * 1000);
   const webhookStore = new WebhookStore(cfg.webhook.bufferSize);
   const avito = new AvitoClient(cfg);
@@ -205,6 +206,56 @@ describe('MCP resources — listing & static reads', () => {
     expect(body2.pending[0].risk).toBe('public');
     // args / execute did not leak:
     expect(body2.pending[0].args).toBeUndefined();
+  });
+
+
+  it('hides pending-actions resource when meta_list_pending_actions is denied', async () => {
+    const { client, ctx, cfg } = await makeRig((config) => {
+      config.denyTools = ['meta_list_pending_actions'];
+    });
+    cleanup = async () => {
+      await client.close();
+      await fs.rm(cfg.tokenFile, { force: true });
+    };
+
+    ctx.pendingStore.create({
+      toolName: 'items_update_price',
+      risk: 'public',
+      summary: 'should not leak',
+      args: {},
+      execute: async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+    });
+
+    const { resources } = await client.listResources();
+    expect(resources.map((r) => r.uri)).not.toContain(PENDING_ACTIONS_URI);
+    await expect(client.readResource({ uri: PENDING_ACTIONS_URI })).rejects.toThrow();
+  });
+
+  it('does not emit pending-actions updates when the listing policy is denied', async () => {
+    const { client, ctx, cfg } = await makeRig((config) => {
+      config.denyTools = ['meta_list_pending_actions'];
+    });
+    cleanup = async () => {
+      await client.close();
+      await fs.rm(cfg.tokenFile, { force: true });
+    };
+
+    const onUpdated = vi.fn();
+    client.setNotificationHandler(ResourceUpdatedNotificationSchema, async (notif) => {
+      onUpdated(notif.params.uri);
+    });
+
+    await client.subscribeResource({ uri: PENDING_ACTIONS_URI });
+    ctx.pendingStore.create({
+      toolName: 'items_update_price',
+      risk: 'public',
+      summary: 'should not notify',
+      args: {},
+      execute: async () => ({ content: [] }),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(onUpdated).not.toHaveBeenCalledWith(PENDING_ACTIONS_URI);
   });
 
   it('emits notifications/resources/updated when pending-actions change', async () => {


### PR DESCRIPTION
### Motivation
- The `avito://state/pending-actions` resource exposed confirmation IDs and summaries without consulting the tool allow/deny policy, creating a policy bypass relative to `meta_list_pending_actions`.
- Subscriptions to that resource also emitted update notifications even when the operator explicitly hid the listing tool.

### Description
- Gate the `avito://state/pending-actions` resource registration with the same `evaluatePolicy('meta_list_pending_actions', 'read', ctx.config)` decision used for the `meta_list_pending_actions` tool by introducing `pendingActionsDecision` and only registering the resource when `.allowed` is true in `src/resources.ts`.
- Ignore `resources/subscribe` requests for `PENDING_ACTIONS_URI` when the decision denies access to prevent subscription updates for a hidden resource by returning early from the subscribe handler in `src/resources.ts`.
- Log an informational message when the pending-actions resource is hidden by policy in `src/resources.ts`.
- Add regression tests in `test/resources.test.ts` that configure `cfg.denyTools = ['meta_list_pending_actions']` and assert the resource is not listed/readable and that denied subscriptions do not receive updates.

### Testing
- Ran `npm run lint` and linting succeeded.
- Ran `npm run typecheck`, `npm run build`, and `npm run generate:manifest` and all completed successfully.
- Ran targeted tests `npm test -- --run test/resources.test.ts` and then the full test suite `npm test -- --run`; all tests passed (the repository test run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d032568083248ffd1fffd32d067e)