### PR TITLE
fix: stream oversized binary responses

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,7 +1,12 @@
 import { logger } from '../logger.js';
 import type { Config } from '../config.js';
 import { USER_AGENT } from '../version.js';
-import { AvitoApiError, AvitoTransportError, MissingCredentialsError, type RequestInfo } from './errors.js';
+import {
+  AvitoApiError,
+  AvitoTransportError,
+  MissingCredentialsError,
+  type RequestInfo,
+} from './errors.js';
 import { TokenStore } from './token-store.js';
 import { RateLimiter, sleep } from './rate-limiter.js';
 import { buildUrl, type Primitive, type QueryValue } from './url.js';
@@ -289,6 +294,45 @@ function isBinaryContent(ct: string): boolean {
   return true;
 }
 
+async function readBinaryBodyWithLimit(
+  resp: Response,
+  maxBinaryBytes: number,
+): Promise<ArrayBuffer> {
+  if (!resp.body) return new ArrayBuffer(0);
+
+  const reader = resp.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      total += value.byteLength;
+      if (total > maxBinaryBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error(
+          `Binary response too large: ${total} bytes > AVITO_MCP_MAX_BINARY_MB limit (${maxBinaryBytes} bytes). ` +
+            `Increase AVITO_MCP_MAX_BINARY_MB or fetch this file via direct HTTP (curl).`,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
+}
+
 async function safeParseResponse<T>(
   resp: Response,
   maxBinaryBytes: number = 20 * 1024 * 1024,
@@ -300,21 +344,14 @@ async function safeParseResponse<T>(
     const cl = resp.headers.get('content-length');
     const declared = cl ? Number.parseInt(cl, 10) : NaN;
     if (Number.isFinite(declared) && declared > maxBinaryBytes) {
-      // drain the body so the socket does not hang
-      try { await resp.arrayBuffer(); } catch { /* ignore */ }
+      await resp.body?.cancel().catch(() => undefined);
       throw new Error(
         `Binary response too large: Content-Length=${declared} bytes > AVITO_MCP_MAX_BINARY_MB limit (${maxBinaryBytes} bytes). ` +
           `Increase AVITO_MCP_MAX_BINARY_MB or fetch this file via direct HTTP (curl).`,
       );
     }
-    const ab = await resp.arrayBuffer();
+    const ab = await readBinaryBodyWithLimit(resp, maxBinaryBytes);
     if (ab.byteLength === 0) return null;
-    if (ab.byteLength > maxBinaryBytes) {
-      throw new Error(
-        `Binary response too large: ${ab.byteLength} bytes > AVITO_MCP_MAX_BINARY_MB limit (${maxBinaryBytes} bytes). ` +
-          `Increase AVITO_MCP_MAX_BINARY_MB or fetch this file via direct HTTP (curl).`,
-      );
-    }
     return {
       __binary: true,
       mimeType: ct.split(';')[0]!.trim(),

--- a/test/binary-response.test.ts
+++ b/test/binary-response.test.ts
@@ -55,7 +55,11 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
   };
 }
 
-function makeClient(overrides: Partial<Config> = {}): { client: AvitoClient; cfg: Config; fetchMock: ReturnType<typeof vi.fn> } {
+function makeClient(overrides: Partial<Config> = {}): {
+  client: AvitoClient;
+  cfg: Config;
+  fetchMock: ReturnType<typeof vi.fn>;
+} {
   const cfg = makeConfig(overrides);
   const fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
@@ -207,10 +211,11 @@ describe('AvitoClient — binary response handling', () => {
     expect(resp.data).toBeNull();
   });
 
-  it('v0.5.1: rejects oversized binary by Content-Length header (no read into memory)', async () => {
+  it('v0.5.1: rejects oversized binary by Content-Length header without reading the body', async () => {
     const rig = makeClient({ maxBinaryMb: 1 }); // 1 MB cap
     cfg = rig.cfg;
     let payloadFetched = false;
+    let bodyCanceled = false;
     rig.fetchMock.mockImplementation(async (url: string) => {
       if (url.endsWith('/token')) {
         return new Response(JSON.stringify({ access_token: 't', expires_in: 3600 }), {
@@ -219,8 +224,16 @@ describe('AvitoClient — binary response handling', () => {
         });
       }
       payloadFetched = true;
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.enqueue(new Uint8Array(100));
+        },
+        cancel() {
+          bodyCanceled = true;
+        },
+      });
       // Server claims 5 MB (5*1024*1024) — client should reject by header alone.
-      return new Response(Buffer.alloc(100), {
+      return new Response(body, {
         status: 200,
         headers: {
           'content-type': 'application/pdf',
@@ -228,15 +241,18 @@ describe('AvitoClient — binary response handling', () => {
         },
       });
     });
-    await expect(
-      rig.client.request({ method: 'GET', path: '/huge.pdf' }),
-    ).rejects.toThrow(/Binary response too large/);
+    await expect(rig.client.request({ method: 'GET', path: '/huge.pdf' })).rejects.toThrow(
+      /Binary response too large/,
+    );
     expect(payloadFetched).toBe(true);
+    expect(bodyCanceled).toBe(true);
   });
 
-  it('v0.5.1: rejects oversized binary by actual size when Content-Length is absent', async () => {
+  it('v0.5.1: rejects oversized binary by actual size while streaming when Content-Length is absent', async () => {
     const rig = makeClient({ maxBinaryMb: 1 });
     cfg = rig.cfg;
+    let chunksRead = 0;
+    let bodyCanceled = false;
     rig.fetchMock.mockImplementation(async (url: string) => {
       if (url.endsWith('/token')) {
         return new Response(JSON.stringify({ access_token: 't', expires_in: 3600 }), {
@@ -244,15 +260,26 @@ describe('AvitoClient — binary response handling', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      // No content-length header; server lies. Real payload is 2 MB.
-      return new Response(Buffer.alloc(2 * 1024 * 1024), {
+      const chunk = new Uint8Array(512 * 1024);
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          chunksRead += 1;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          bodyCanceled = true;
+        },
+      });
+      return new Response(body, {
         status: 200,
         headers: { 'content-type': 'application/pdf' }, // no content-length
       });
     });
-    await expect(
-      rig.client.request({ method: 'GET', path: '/huge.pdf' }),
-    ).rejects.toThrow(/Binary response too large/);
+    await expect(rig.client.request({ method: 'GET', path: '/huge.pdf' })).rejects.toThrow(
+      /Binary response too large/,
+    );
+    expect(chunksRead).toBeLessThan(5);
+    expect(bodyCanceled).toBe(true);
   });
 
   it('v0.5.1: accepts binary that fits under the limit', async () => {


### PR DESCRIPTION
### Motivation
- The client previously used `resp.arrayBuffer()` when rejecting oversized binary responses which buffered the entire body in memory and could enable memory/availability DoS.  
- The goal is to enforce the configured `maxBinaryMb` cap in a fail-fast way without downloading or buffering the full payload.

### Description
- Replace `arrayBuffer()` reads for binary content with a streaming reader by adding `readBinaryBodyWithLimit(resp, maxBinaryBytes)` and assemble the `ArrayBuffer` only when the body fits the cap in `src/core/client.ts`.
- For declared-oversize (`Content-Length` > cap) immediately cancel the response body with `resp.body?.cancel()` instead of draining it into memory in `src/core/client.ts`.
- Update `safeParseResponse` to use the new streaming reader and preserve the existing structured `BinaryResponse` envelope (mime, sizeBytes, base64).
- Strengthen `test/binary-response.test.ts` to assert that declared-oversize responses are canceled without reading and that streaming responses are canceled once the cap is exceeded.

### Testing
- Ran `npm run typecheck` and it completed successfully.  
- Ran targeted tests `npm test -- test/binary-response.test.ts` and the updated binary-response tests passed.  
- Built and generated the manifest with `npm run build && npm run generate:manifest` and then ran the full test suite with `npm test`, which reported all tests passing.  
- Ran `npm run lint` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d03322f08324b6847aa3e4604ad8)