### PR TITLE
fix: harden confirmation secret checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,15 +76,16 @@ Profile_id=
 # AVITO_MCP_CONFIRMATION_TTL_SEC=900
 
 # v0.5.0: hard-confirmation. Если задано — meta_confirm_action требует параметр
-# confirmation_secret, сравниваемый constant-time с этой env-переменной. Без
-# совпадения подтверждение отклоняется. Pending action НЕ удаляется при отказе —
-# можно повторить с правильным секретом до истечения TTL.
+# confirmation_secret, сравниваемый constant-time с этой env-переменной. Значение
+# должно быть случайным и иметь длину минимум 32 символа. Без совпадения
+# подтверждение отклоняется. После 5 неправильных попыток pending action удаляется.
 #
 # Эта переменная переводит confirmation flow из soft-confirmation (агент сам
 # может вызвать meta_confirm_action) в hard-confirmation (агент должен получить
 # секрет из внешнего канала, чаще всего ввод человека в чате клиента).
 # Сильнее всего работает в паре с MCP-клиентом, который показывает confirmation_id
 # человеку и просит ввести секрет вручную.
+# Example: openssl rand -base64 32
 # AVITO_MCP_CONFIRMATION_SECRET=
 
 # v0.5.1: лимит размера binary-ответа в MB (PDF labels, audio recordings).

--- a/src/config.ts
+++ b/src/config.ts
@@ -151,9 +151,7 @@ const ConfigSchema = z.object({
   profileId: z.coerce.number().int().positive('Profile_id must be a positive integer').optional(),
   baseUrl: z.string().url().default('https://api.avito.ru'),
   tokenFile: z.string().default(defaultTokenFile()),
-  logLevel: z
-    .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
-    .default('info'),
+  logLevel: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),
   mode: z.enum(['read_only', 'guarded', 'full_access']).default('full_access'),
   allowTools: z.array(z.string()).default([]),
   denyTools: z.array(z.string()).default([]),
@@ -162,7 +160,10 @@ const ConfigSchema = z.object({
   maxUploadMb: z.number().int().positive().default(15),
   confirmationMode: z.enum(['off', 'money_public', 'all_destructive']).default('money_public'),
   confirmationTtlSec: z.number().int().positive().default(900),
-  confirmationSecret: z.string().optional(),
+  confirmationSecret: z
+    .string()
+    .min(32, 'AVITO_MCP_CONFIRMATION_SECRET must be at least 32 characters')
+    .optional(),
   maxBinaryMb: z.number().int().positive().default(20),
   // v0.7.0 ───────────────────────────────────────────────────
   /** Default for `dryRun` parameter on write/money/public tools. */
@@ -258,7 +259,8 @@ function load(): Config {
     exposeAuthTools: parseBool(process.env.AVITO_MCP_EXPOSE_AUTH_TOOLS),
     allowedUploadDirs: parseToolList(process.env.AVITO_MCP_ALLOWED_UPLOAD_DIRS),
     maxUploadMb: parsePositiveInt(process.env.AVITO_MCP_MAX_UPLOAD_MB, 15),
-    confirmationMode: (process.env.AVITO_MCP_CONFIRMATION_MODE as ConfirmationMode | undefined) ?? 'money_public',
+    confirmationMode:
+      (process.env.AVITO_MCP_CONFIRMATION_MODE as ConfirmationMode | undefined) ?? 'money_public',
     confirmationTtlSec: parsePositiveInt(process.env.AVITO_MCP_CONFIRMATION_TTL_SEC, 900),
     confirmationSecret: process.env.AVITO_MCP_CONFIRMATION_SECRET,
     maxBinaryMb: parsePositiveInt(process.env.AVITO_MCP_MAX_BINARY_MB, 20),
@@ -270,7 +272,9 @@ function load(): Config {
 
   const parsed = ConfigSchema.safeParse(raw);
   if (!parsed.success) {
-    const issues = parsed.error.issues.map((i) => `  - ${i.path.join('.')}: ${i.message}`).join('\n');
+    const issues = parsed.error.issues
+      .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
+      .join('\n');
     process.stderr.write(
       `Invalid .env (${envFile}):\n${issues}\n\nSee .env.example for the expected format.\n`,
     );

--- a/src/domains/meta.ts
+++ b/src/domains/meta.ts
@@ -60,9 +60,7 @@ export const register: DomainRegister = (server, ctx) => {
         const snaps = ctx.client.rateLimiter.getStatus();
         if (snaps.length === 0) {
           return {
-            content: [
-              { type: 'text', text: 'No data: no requests to Avito have been made yet.' },
-            ],
+            content: [{ type: 'text', text: 'No data: no requests to Avito have been made yet.' }],
             structuredContent: { snapshots: [], count: 0 },
           };
         }
@@ -347,109 +345,124 @@ export const register: DomainRegister = (server, ctx) => {
   // ───────────────── meta_confirm_action ─────────────────
 
   const requireSecret = !!ctx.config.confirmationSecret;
-  if (confirmDecision.allowed) server.registerTool(
-    'meta_confirm_action',
-    {
-      title: '✓ Confirm a pending action',
-      description:
-        '⚠️ Executes a previously deferred action by its confirmation_id. ' +
-        'Use ONLY after explicit human confirmation — the flow is designed as a server-side ' +
-        'two-step guard against accidental one-shot execution, not as cryptographic protection ' +
-        'against an autonomous agent. Confirmation is single-use: the id is deleted after a successful call. ' +
-        (requireSecret
-          ? 'AVITO_MCP_CONFIRMATION_SECRET is set: a confirmation_secret parameter is additionally required ' +
-            '(compared constant-time). Without it the confirmation is rejected. This is hard-confirmation ' +
-            '— the secret is generated and kept by a human, and the agent cannot obtain it.'
-          : 'AVITO_MCP_CONFIRMATION_SECRET is not set — soft-confirmation is in effect. ' +
-            'Set the env variable to switch to hard-confirmation.'),
-      inputSchema: {
-        confirmation_id: z
-          .string()
-          .min(16)
-          .describe('ID of the pending action (returned in the confirmation_id field on the first tool call).'),
-        confirmation_secret: z
-          .string()
-          .optional()
-          .describe(
-            requireSecret
-              ? 'The required AVITO_MCP_CONFIRMATION_SECRET value (entered by a human).'
-              : 'Not used when AVITO_MCP_CONFIRMATION_SECRET is not set.',
-          ),
+  const failedConfirmationAttempts = new Map<string, number>();
+  const maxFailedConfirmationAttempts = 5;
+  if (confirmDecision.allowed)
+    server.registerTool(
+      'meta_confirm_action',
+      {
+        title: '✓ Confirm a pending action',
+        description:
+          '⚠️ Executes a previously deferred action by its confirmation_id. ' +
+          'Use ONLY after explicit human confirmation — the flow is designed as a server-side ' +
+          'two-step guard against accidental one-shot execution, not as cryptographic protection ' +
+          'against an autonomous agent. Confirmation is single-use: the id is deleted after a successful call. ' +
+          (requireSecret
+            ? 'AVITO_MCP_CONFIRMATION_SECRET is set: a confirmation_secret parameter is additionally required ' +
+              '(compared constant-time). Without it the confirmation is rejected. This is hard-confirmation ' +
+              '— the secret is generated and kept by a human, and the agent cannot obtain it.'
+            : 'AVITO_MCP_CONFIRMATION_SECRET is not set — soft-confirmation is in effect. ' +
+              'Set the env variable to switch to hard-confirmation.'),
+        inputSchema: {
+          confirmation_id: z
+            .string()
+            .min(16)
+            .describe(
+              'ID of the pending action (returned in the confirmation_id field on the first tool call).',
+            ),
+          confirmation_secret: z
+            .string()
+            .optional()
+            .describe(
+              requireSecret
+                ? 'The required AVITO_MCP_CONFIRMATION_SECRET value (entered by a human).'
+                : 'Not used when AVITO_MCP_CONFIRMATION_SECRET is not set.',
+            ),
+        },
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
+        _meta: { risk: 'write', environment: 'local' },
       },
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: false,
-        openWorldHint: true,
-      },
-      _meta: { risk: 'write', environment: 'local' },
-    },
-    async (args): Promise<CallToolResult> => {
-      const id = String(args.confirmation_id ?? '');
+      async (args): Promise<CallToolResult> => {
+        const id = String(args.confirmation_id ?? '');
 
-      // Hard-confirmation: verify the secret BEFORE any other action.
-      if (requireSecret) {
-        const provided = typeof args.confirmation_secret === 'string' ? args.confirmation_secret : '';
-        if (!provided || !secretsMatch(provided, ctx.config.confirmationSecret!)) {
-          logger.warn(
-            { confirmation_id: id, hasSecret: !!provided },
-            'confirmation rejected: bad or missing confirmation_secret',
-          );
+        const pending = ctx.pendingStore.get(id);
+        if (!pending) {
           return {
             isError: true,
             content: [
               {
                 type: 'text',
-                text:
-                  'Bad or missing confirmation_secret. AVITO_MCP_CONFIRMATION_SECRET is configured — ' +
-                  'every confirmation requires the human-typed secret. Pending action is NOT deleted by this rejection; ' +
-                  'retry with the correct secret before the TTL expires, or call meta_cancel_action to discard it.',
+                text: `Confirmation '${id}' not found. Possible causes: invalid id, expired TTL (${ctx.config.confirmationTtlSec}s), or already confirmed or cancelled.`,
               },
             ],
           };
         }
-      }
 
-      const pending = ctx.pendingStore.get(id);
-      if (!pending) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: 'text',
-              text: `Confirmation '${id}' not found. Possible causes: invalid id, expired TTL (${ctx.config.confirmationTtlSec}s), or already confirmed or cancelled.`,
-            },
-          ],
-        };
-      }
-      // Re-evaluate policy — the user may have changed the config between create and confirm.
-      const decision = evaluatePolicy(pending.toolName, pending.risk, ctx.config);
-      if (!decision.allowed) {
+        // Hard-confirmation: only check the reusable secret after a valid pending id
+        // exists. This avoids turning arbitrary/nonexistent confirmation_id values
+        // into an oracle for testing global secret guesses.
+        if (requireSecret) {
+          const provided =
+            typeof args.confirmation_secret === 'string' ? args.confirmation_secret : '';
+          if (!provided || !secretsMatch(provided, ctx.config.confirmationSecret!)) {
+            const failedAttempts = (failedConfirmationAttempts.get(id) ?? 0) + 1;
+            failedConfirmationAttempts.set(id, failedAttempts);
+            const locked = failedAttempts >= maxFailedConfirmationAttempts;
+            if (locked) {
+              ctx.pendingStore.delete(id);
+              failedConfirmationAttempts.delete(id);
+            }
+            logger.warn(
+              { confirmation_id: id, hasSecret: !!provided, failedAttempts, locked },
+              'confirmation rejected: bad or missing confirmation_secret',
+            );
+            return {
+              isError: true,
+              content: [
+                {
+                  type: 'text',
+                  text: locked
+                    ? 'Confirmation rejected. Too many bad or missing confirmation_secret attempts; pending action deleted.'
+                    : 'Confirmation rejected. Bad or missing confirmation_secret. Pending action is NOT deleted by this rejection; retry with the correct secret before the TTL expires, or call meta_cancel_action to discard it.',
+                },
+              ],
+            };
+          }
+          failedConfirmationAttempts.delete(id);
+        }
+        // Re-evaluate policy — the user may have changed the config between create and confirm.
+        const decision = evaluatePolicy(pending.toolName, pending.risk, ctx.config);
+        if (!decision.allowed) {
+          ctx.pendingStore.delete(id);
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: `Tool '${pending.toolName}' is no longer allowed by policy: ${decision.reason}. Pending action deleted.`,
+              },
+            ],
+          };
+        }
+        // One-time use: delete BEFORE executing, so a repeated confirm cannot succeed even on a race.
         ctx.pendingStore.delete(id);
-        return {
-          isError: true,
-          content: [
-            {
-              type: 'text',
-              text: `Tool '${pending.toolName}' is no longer allowed by policy: ${decision.reason}. Pending action deleted.`,
-            },
-          ],
-        };
-      }
-      // One-time use: delete BEFORE executing, so a repeated confirm cannot succeed even on a race.
-      ctx.pendingStore.delete(id);
-      logger.info(
-        {
-          tool: pending.toolName,
-          risk: pending.risk,
-          confirmation_id: id,
-          hardConfirmation: requireSecret,
-        },
-        'pending action confirmed and executing',
-      );
-      return pending.execute();
-    },
-  );
+        logger.info(
+          {
+            tool: pending.toolName,
+            risk: pending.risk,
+            confirmation_id: id,
+            hardConfirmation: requireSecret,
+          },
+          'pending action confirmed and executing',
+        );
+        return pending.execute();
+      },
+    );
 
   if (!confirmDecision.allowed) {
     logger.info(
@@ -460,42 +473,40 @@ export const register: DomainRegister = (server, ctx) => {
 
   // ───────────────── meta_cancel_action ─────────────────
 
-  if (cancelDecision.allowed) server.registerTool(
-    'meta_cancel_action',
-    {
-      title: '✗ Cancel a pending action',
-      description:
-        'Cancels a previously deferred action. After cancellation the confirmation_id is no longer valid.',
-      inputSchema: {
-        confirmation_id: z
-          .string()
-          .min(16)
-          .describe('ID of the pending action to cancel.'),
+  if (cancelDecision.allowed)
+    server.registerTool(
+      'meta_cancel_action',
+      {
+        title: '✗ Cancel a pending action',
+        description:
+          'Cancels a previously deferred action. After cancellation the confirmation_id is no longer valid.',
+        inputSchema: {
+          confirmation_id: z.string().min(16).describe('ID of the pending action to cancel.'),
+        },
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+        _meta: { risk: 'write', environment: 'local' },
       },
-      annotations: {
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: true,
-        openWorldHint: false,
+      async (args): Promise<CallToolResult> => {
+        const id = String(args.confirmation_id ?? '');
+        const existed = ctx.pendingStore.delete(id);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: existed
+                ? `Pending action '${id}' cancelled.`
+                : `Pending action '${id}' not found (it may have already expired, been confirmed, or been cancelled).`,
+            },
+          ],
+          structuredContent: { confirmation_id: id, cancelled: existed },
+        };
       },
-      _meta: { risk: 'write', environment: 'local' },
-    },
-    async (args): Promise<CallToolResult> => {
-      const id = String(args.confirmation_id ?? '');
-      const existed = ctx.pendingStore.delete(id);
-      return {
-        content: [
-          {
-            type: 'text',
-            text: existed
-              ? `Pending action '${id}' cancelled.`
-              : `Pending action '${id}' not found (it may have already expired, been confirmed, or been cancelled).`,
-          },
-        ],
-        structuredContent: { confirmation_id: id, cancelled: existed },
-      };
-    },
-  );
+    );
 
   if (!cancelDecision.allowed) {
     logger.info(
@@ -506,62 +517,67 @@ export const register: DomainRegister = (server, ctx) => {
 
   // ───────────────── meta_list_pending_actions ─────────────────
 
-  if (listDecision.allowed) server.registerTool(
-    'meta_list_pending_actions',
-    {
-      title: 'Pending actions: list',
-      description:
-        'Lists the current pending actions awaiting confirmation. Args are not shown — ' +
-        'only tool name, risk, a brief summary, and the creation and expiration times. ' +
-        'Use it to diagnose "what did I just ask to confirm".',
-      inputSchema: {},
-      annotations: {
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-        openWorldHint: false,
-      },
-      _meta: { risk: 'read', environment: 'local' },
-    },
-    async (): Promise<CallToolResult> => {
-      const items = ctx.pendingStore.list();
-      if (items.length === 0) {
-        return {
-          content: [{ type: 'text', text: 'No pending actions.' }],
-          structuredContent: { pending: [], count: 0, confirmation_mode: ctx.config.confirmationMode },
-        };
-      }
-      const view = items.map((a) => ({
-        id: a.id,
-        tool: a.toolName,
-        risk: a.risk,
-        summary: a.summary,
-        created_at: new Date(a.createdAt).toISOString(),
-        expires_at: new Date(a.expiresAt).toISOString(),
-        // Not: args, because they may contain item_id, message_id, prices, etc. in an undesirable amount
-        // Not: execute, because it is a closure
-      }));
-      const requiresHint =
-        `\n\nConfirmation mode = ${ctx.config.confirmationMode}. ` +
-        `Require confirmation in this mode: ` +
-        (requiresConfirmation('money', ctx.config) ? 'money ' : '') +
-        (requiresConfirmation('public', ctx.config) ? 'public ' : '') +
-        (requiresConfirmation('write', ctx.config) ? 'write ' : '');
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(view, null, 2) + requiresHint,
-          },
-        ],
-        structuredContent: {
-          pending: view,
-          count: view.length,
-          confirmation_mode: ctx.config.confirmationMode,
+  if (listDecision.allowed)
+    server.registerTool(
+      'meta_list_pending_actions',
+      {
+        title: 'Pending actions: list',
+        description:
+          'Lists the current pending actions awaiting confirmation. Args are not shown — ' +
+          'only tool name, risk, a brief summary, and the creation and expiration times. ' +
+          'Use it to diagnose "what did I just ask to confirm".',
+        inputSchema: {},
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
         },
-      };
-    },
-  );
+        _meta: { risk: 'read', environment: 'local' },
+      },
+      async (): Promise<CallToolResult> => {
+        const items = ctx.pendingStore.list();
+        if (items.length === 0) {
+          return {
+            content: [{ type: 'text', text: 'No pending actions.' }],
+            structuredContent: {
+              pending: [],
+              count: 0,
+              confirmation_mode: ctx.config.confirmationMode,
+            },
+          };
+        }
+        const view = items.map((a) => ({
+          id: a.id,
+          tool: a.toolName,
+          risk: a.risk,
+          summary: a.summary,
+          created_at: new Date(a.createdAt).toISOString(),
+          expires_at: new Date(a.expiresAt).toISOString(),
+          // Not: args, because they may contain item_id, message_id, prices, etc. in an undesirable amount
+          // Not: execute, because it is a closure
+        }));
+        const requiresHint =
+          `\n\nConfirmation mode = ${ctx.config.confirmationMode}. ` +
+          `Require confirmation in this mode: ` +
+          (requiresConfirmation('money', ctx.config) ? 'money ' : '') +
+          (requiresConfirmation('public', ctx.config) ? 'public ' : '') +
+          (requiresConfirmation('write', ctx.config) ? 'write ' : '');
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(view, null, 2) + requiresHint,
+            },
+          ],
+          structuredContent: {
+            pending: view,
+            count: view.length,
+            confirmation_mode: ctx.config.confirmationMode,
+          },
+        };
+      },
+    );
   if (!listDecision.allowed) {
     logger.info(
       { tool: 'meta_list_pending_actions', risk: 'read', reason: listDecision.reason },

--- a/test/confirmation.test.ts
+++ b/test/confirmation.test.ts
@@ -269,9 +269,11 @@ describe('confirmation flow', () => {
     });
     const id = extractConfirmationId(parseText(first.content));
     // Manually expire by reaching into the store (faster than real wait)
-    const action = (rig.pendingStore as unknown as {
-      actions: Map<string, { expiresAt: number }>;
-    }).actions.get(id)!;
+    const action = (
+      rig.pendingStore as unknown as {
+        actions: Map<string, { expiresAt: number }>;
+      }
+    ).actions.get(id)!;
     action.expiresAt = Date.now() - 1;
     const r = await rig.client.callTool({
       name: 'meta_confirm_action',
@@ -333,7 +335,9 @@ describe('hard-confirmation (AVITO_MCP_CONFIRMATION_SECRET)', () => {
   });
 
   it('confirm without secret is rejected and pending NOT deleted', async () => {
-    const rig = await makeRig('money_public', 900, { confirmationSecret: 'topsecret123' });
+    const rig = await makeRig('money_public', 900, {
+      confirmationSecret: 'topsecret123456789012345678901234',
+    });
     cfg = rig.cfg;
     const first = await rig.client.callTool({
       name: 'money_tool',
@@ -347,14 +351,16 @@ describe('hard-confirmation (AVITO_MCP_CONFIRMATION_SECRET)', () => {
       arguments: { confirmation_id: id },
     });
     expect(noSecret.isError).toBe(true);
-    expect(parseText(noSecret.content)).toMatch(/AVITO_MCP_CONFIRMATION_SECRET/);
+    expect(parseText(noSecret.content)).toMatch(/Bad or missing confirmation_secret/);
     // Pending action should still exist — bad secret doesn't burn it (allows retry).
     expect(rig.pendingStore.size()).toBe(1);
     await rig.client.close();
   });
 
   it('confirm with wrong secret is rejected, pending NOT deleted', async () => {
-    const rig = await makeRig('money_public', 900, { confirmationSecret: 'real-secret' });
+    const rig = await makeRig('money_public', 900, {
+      confirmationSecret: 'real-secret-123456789012345678901',
+    });
     cfg = rig.cfg;
     const first = await rig.client.callTool({
       name: 'money_tool',
@@ -371,7 +377,9 @@ describe('hard-confirmation (AVITO_MCP_CONFIRMATION_SECRET)', () => {
   });
 
   it('confirm with correct secret executes and burns pending', async () => {
-    const rig = await makeRig('money_public', 900, { confirmationSecret: 'a-strong-secret' });
+    const rig = await makeRig('money_public', 900, {
+      confirmationSecret: 'a-strong-secret-123456789012345678',
+    });
     cfg = rig.cfg;
     const first = await rig.client.callTool({
       name: 'money_tool',
@@ -381,7 +389,7 @@ describe('hard-confirmation (AVITO_MCP_CONFIRMATION_SECRET)', () => {
     const fetchBefore = rig.fetchMock.mock.calls.length;
     const r = await rig.client.callTool({
       name: 'meta_confirm_action',
-      arguments: { confirmation_id: id, confirmation_secret: 'a-strong-secret' },
+      arguments: { confirmation_id: id, confirmation_secret: 'a-strong-secret-123456789012345678' },
     });
     expect(r.isError).not.toBe(true);
     expect(rig.fetchMock.mock.calls.length).toBeGreaterThan(fetchBefore);
@@ -389,8 +397,61 @@ describe('hard-confirmation (AVITO_MCP_CONFIRMATION_SECRET)', () => {
     await rig.client.close();
   });
 
+  it('checks pending id before secret to avoid a global secret oracle', async () => {
+    const rig = await makeRig('money_public', 900, {
+      confirmationSecret: 'oracle-secret-123456789012345678',
+    });
+    cfg = rig.cfg;
+    const wrong = await rig.client.callTool({
+      name: 'meta_confirm_action',
+      arguments: { confirmation_id: '0000000000000000', confirmation_secret: 'wrong-guess' },
+    });
+    const correct = await rig.client.callTool({
+      name: 'meta_confirm_action',
+      arguments: {
+        confirmation_id: '0000000000000000',
+        confirmation_secret: 'oracle-secret-123456789012345678',
+      },
+    });
+    expect(wrong.isError).toBe(true);
+    expect(correct.isError).toBe(true);
+    expect(parseText(wrong.content)).toEqual(parseText(correct.content));
+    expect(parseText(wrong.content)).toMatch(/not found/);
+    await rig.client.close();
+  });
+
+  it('deletes a pending action after too many bad secret attempts', async () => {
+    const rig = await makeRig('money_public', 900, {
+      confirmationSecret: 'lockout-secret-12345678901234567',
+    });
+    cfg = rig.cfg;
+    const first = await rig.client.callTool({
+      name: 'money_tool',
+      arguments: { item_id: 1, vas_id: 'x' },
+    });
+    const id = extractConfirmationId(parseText(first.content));
+    for (let i = 0; i < 4; i++) {
+      const r = await rig.client.callTool({
+        name: 'meta_confirm_action',
+        arguments: { confirmation_id: id, confirmation_secret: `wrong-${i}` },
+      });
+      expect(r.isError).toBe(true);
+      expect(rig.pendingStore.size()).toBe(1);
+    }
+    const locked = await rig.client.callTool({
+      name: 'meta_confirm_action',
+      arguments: { confirmation_id: id, confirmation_secret: 'wrong-4' },
+    });
+    expect(locked.isError).toBe(true);
+    expect(parseText(locked.content)).toMatch(/Too many/);
+    expect(rig.pendingStore.size()).toBe(0);
+    await rig.client.close();
+  });
+
   it('rejects length-mismatch without timing leak (different-length secret)', async () => {
-    const rig = await makeRig('money_public', 900, { confirmationSecret: 'same-length-12' });
+    const rig = await makeRig('money_public', 900, {
+      confirmationSecret: 'same-length-secret-123456789012345',
+    });
     cfg = rig.cfg;
     const first = await rig.client.callTool({
       name: 'money_tool',
@@ -400,7 +461,7 @@ describe('hard-confirmation (AVITO_MCP_CONFIRMATION_SECRET)', () => {
     // Same length, different content
     const sameLen = await rig.client.callTool({
       name: 'meta_confirm_action',
-      arguments: { confirmation_id: id, confirmation_secret: 'WRONG-LEN12_X'.slice(0, 14) },
+      arguments: { confirmation_id: id, confirmation_secret: 'WRONG-length-secret-1234567890123' },
     });
     expect(sameLen.isError).toBe(true);
     // Different length


### PR DESCRIPTION
### Motivation
- The hard-confirmation flow accepted arbitrarily short/human-memorable `AVITO_MCP_CONFIRMATION_SECRET` values and compared the secret before verifying a pending `confirmation_id`, creating an online oracle for brute-forcing the global secret.
- The change aims to remove the oracle, raise the minimum secret strength, and add limited lockout behaviour to reduce online guessing risk while retaining the one-shot pending-confirmation UX.

### Description
- Enforce a minimum length for the global secret by changing the config schema so `confirmationSecret` is a string with `.min(32)` validation (see `src/config.ts`).
- In `meta_confirm_action` reorder logic to look up the pending action first and only compare the reusable secret for existing pending IDs to avoid revealing whether an ID exists (`src/domains/meta.ts`).
- Add a per-pending failed-secret attempt tracker and delete the pending action after `5` failed attempts (lockout), while preserving the prior behaviour of not deleting on ordinary wrong guesses until the threshold (`src/domains/meta.ts`).
- Update tests to cover the oracle fix and lockout behaviour and adjust hard-confirmation test secrets to satisfy the new minimum length (`test/confirmation.test.ts`).
- Update `.env.example` to document the 32+ character requirement and the lockout behaviour.

### Testing
- Ran type checking with `npm run typecheck` and it succeeded.
- Ran linter with `npm run lint` and it succeeded.
- Ran targeted unit tests `npm test -- --run test/confirmation.test.ts` and they passed (20 tests in that file passed in the run).
- Built and generated manifest with `npm run build` and `npm run generate:manifest` and both succeeded.
- Ran full test suite with `npm test` and all tests passed (`202` tests passed, `6` skipped in this environment).
- Note: `npx prettier --write .env.example` returned a parser error for `.env.example` (Prettier could not infer a parser), but TypeScript files were formatted and the rest of the CI checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d03249ac8324acfc277bdcc15a9f)