### PR TITLE
Require confirmation for image uploads (messenger_upload_images)

### DIFF
--- a/src/domains/messenger.ts
+++ b/src/domains/messenger.ts
@@ -21,7 +21,7 @@ import { z } from 'zod';
 import { logger } from '../logger.js';
 import { defineTool, type DomainRegister } from '../core/tool-factory.js';
 import { errorToMcpContent, MissingCredentialsError } from '../core/errors.js';
-import { evaluatePolicy } from '../core/policy.js';
+import { evaluatePolicy, requiresConfirmation } from '../core/policy.js';
 import { validateUpload, UploadGuardError } from '../core/upload-guard.js';
 
 export const register: DomainRegister = (server, ctx) => {
@@ -341,6 +341,113 @@ export const register: DomainRegister = (server, ctx) => {
     return;
   }
   const maxBytes = ctx.config.maxUploadMb * 1024 * 1024;
+  const executeUpload = async (args: Record<string, unknown>): Promise<CallToolResult> => {
+    try {
+      const userId = (args.user_id as number | undefined) ?? ctx.config.profileId;
+      if (userId === undefined) {
+        // v0.7.4: no user_id arg and no Profile_id configured → can't build the path.
+        throw new MissingCredentialsError(
+          'messenger_upload_images requires Profile_id (or an explicit user_id). ' +
+            'Set Profile_id env var or pass user_id.',
+        );
+      }
+      const paths = args.paths as string[];
+
+      // Validate ALL files before starting the upload — fail-fast.
+      const validated = [];
+      for (const p of paths) {
+        try {
+          validated.push(
+            await validateUpload(p, {
+              allowedDirs: ctx.config.allowedUploadDirs,
+              maxBytes,
+            }),
+          );
+        } catch (err) {
+          if (err instanceof UploadGuardError) {
+            return {
+              isError: true,
+              content: [{ type: 'text', text: err.message }],
+            };
+          }
+          throw err;
+        }
+      }
+
+      const form = new FormData();
+      for (const v of validated) {
+        const ab = v.data.buffer.slice(v.data.byteOffset, v.data.byteOffset + v.data.byteLength);
+        form.append('uploadfile[]', new Blob([ab as ArrayBuffer], { type: v.mime }), v.filename);
+      }
+
+      const response = await ctx.client.request({
+        method: 'POST',
+        path: '/messenger/v1/accounts/{user_id}/uploadImages',
+        pathParams: { user_id: userId },
+        body: form,
+        bodyContentType: 'multipart/form-data',
+        domain: 'messenger',
+      });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `status=${response.status}\n${JSON.stringify(response.data, null, 2)}`,
+          },
+        ],
+      };
+    } catch (err) {
+      return errorToMcpContent(err);
+    }
+  };
+
+  const uploadHandler = async (rawArgs: Record<string, unknown>): Promise<CallToolResult> => {
+    const args = rawArgs ?? {};
+
+    if (requiresConfirmation('write', ctx.config)) {
+      const paths = Array.isArray(args.paths) ? args.paths : [];
+      const pending = ctx.pendingStore.create({
+        toolName: 'messenger_upload_images',
+        risk: 'write',
+        summary: `Upload ${paths.length} image(s) from local disk`,
+        args,
+        execute: () => executeUpload(args),
+      });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                requires_confirmation: true,
+                confirmation_id: pending.id,
+                tool: 'messenger_upload_images',
+                risk: 'write',
+                summary: pending.summary,
+                expires_at: new Date(pending.expiresAt).toISOString(),
+                next_step:
+                  'Call meta_confirm_action with this confirmation_id ONLY after explicit human approval. ' +
+                  'Confirmation flow is a server-side two-step safety guard against accidental one-shot execution; ' +
+                  'it is not a cryptographic human-approval mechanism by itself.',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        structuredContent: {
+          requires_confirmation: true,
+          confirmation_id: pending.id,
+          tool: 'messenger_upload_images',
+          risk: 'write',
+          expires_at: new Date(pending.expiresAt).toISOString(),
+        },
+      };
+    }
+
+    return executeUpload(args);
+  };
+
   server.registerTool(
     'messenger_upload_images',
     {
@@ -376,64 +483,6 @@ export const register: DomainRegister = (server, ctx) => {
       },
       _meta: { risk: 'write', environment: 'prod', accessesLocalFiles: true },
     },
-    async (args): Promise<CallToolResult> => {
-      try {
-        const userId = (args.user_id as number | undefined) ?? ctx.config.profileId;
-        if (userId === undefined) {
-          // v0.7.4: no user_id arg and no Profile_id configured → can't build the path.
-          throw new MissingCredentialsError(
-            'messenger_upload_images requires Profile_id (or an explicit user_id). ' +
-              'Set Profile_id env var or pass user_id.',
-          );
-        }
-        const paths = args.paths as string[];
-
-        // Validate ALL files before starting the upload — fail-fast.
-        const validated = [];
-        for (const p of paths) {
-          try {
-            validated.push(
-              await validateUpload(p, {
-                allowedDirs: ctx.config.allowedUploadDirs,
-                maxBytes,
-              }),
-            );
-          } catch (err) {
-            if (err instanceof UploadGuardError) {
-              return {
-                isError: true,
-                content: [{ type: 'text', text: err.message }],
-              };
-            }
-            throw err;
-          }
-        }
-
-        const form = new FormData();
-        for (const v of validated) {
-          const ab = v.data.buffer.slice(v.data.byteOffset, v.data.byteOffset + v.data.byteLength);
-          form.append('uploadfile[]', new Blob([ab as ArrayBuffer], { type: v.mime }), v.filename);
-        }
-
-        const response = await ctx.client.request({
-          method: 'POST',
-          path: '/messenger/v1/accounts/{user_id}/uploadImages',
-          pathParams: { user_id: userId },
-          body: form,
-          bodyContentType: 'multipart/form-data',
-          domain: 'messenger',
-        });
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `status=${response.status}\n${JSON.stringify(response.data, null, 2)}`,
-            },
-          ],
-        };
-      } catch (err) {
-        return errorToMcpContent(err);
-      }
-    },
+    uploadHandler,
   );
 };

--- a/test/confirmation.test.ts
+++ b/test/confirmation.test.ts
@@ -23,6 +23,7 @@ import { AvitoClient } from '../src/core/client.js';
 import { defineTool, type ToolContext } from '../src/core/tool-factory.js';
 import { PendingActionStore } from '../src/core/pending-actions.js';
 import { register as registerMeta } from '../src/domains/meta.js';
+import { register as registerMessenger } from '../src/domains/messenger.js';
 import type { Config, ConfirmationMode } from '../src/config.js';
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
@@ -138,6 +139,49 @@ async function makeRig(
   return { server, client: client2, cfg, ctx, fetchMock, pendingStore };
 }
 
+async function makeUploadRig(confirmationMode: ConfirmationMode) {
+  const uploadDir = await fs.mkdtemp(join(tmpdir(), 'avito-upload-confirm-'));
+  const cfg = makeConfig({
+    confirmationMode,
+    allowedUploadDirs: [uploadDir],
+    tokenFile: join(tmpdir(), `avito-token-${randomBytes(6).toString('hex')}.json`),
+  });
+  const imagePath = join(uploadDir, 'one.png');
+  await fs.writeFile(
+    imagePath,
+    Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=', 'base64'),
+  );
+
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url.endsWith('/token')) {
+      return new Response(
+        JSON.stringify({ access_token: 'tk', expires_in: 3600, token_type: 'bearer' }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    return new Response(JSON.stringify({ uploaded: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const client = new AvitoClient(cfg, {
+    retry: { retry429BaseMs: 1, max429Retries: 0, retry5xxBackoffMs: 1, max5xxRetries: 0 },
+  });
+  const pendingStore = new PendingActionStore(cfg.confirmationTtlSec * 1000);
+  const ctx: ToolContext = { client, config: cfg, pendingStore };
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  registerMessenger(server, ctx);
+  registerMeta(server, ctx);
+
+  const [a, b] = InMemoryTransport.createLinkedPair();
+  await server.connect(a);
+  const client2 = new Client({ name: 'test', version: '0.0.0' }, { capabilities: {} });
+  await client2.connect(b);
+  return { server, client: client2, cfg, ctx, fetchMock, pendingStore, uploadDir, imagePath };
+}
+
 function parseText(content: unknown): string {
   return (content as Array<{ type: string; text: string }>)[0]!.text;
 }
@@ -190,6 +234,35 @@ describe('confirmation flow', () => {
     expect(JSON.parse(parseText(r.content)).requires_confirmation).toBe(true);
     expect(rig.fetchMock).not.toHaveBeenCalled();
     await rig.client.close();
+  });
+
+
+  it('custom messenger_upload_images requires confirmation in all_destructive mode', async () => {
+    const rig = await makeUploadRig('all_destructive');
+    cfg = rig.cfg;
+
+    const first = await rig.client.callTool({
+      name: 'messenger_upload_images',
+      arguments: { paths: [rig.imagePath] },
+    });
+
+    const payload = JSON.parse(parseText(first.content));
+    expect(payload.requires_confirmation).toBe(true);
+    expect(payload.tool).toBe('messenger_upload_images');
+    expect(payload.risk).toBe('write');
+    expect(rig.fetchMock).not.toHaveBeenCalled();
+    expect(rig.pendingStore.size()).toBe(1);
+
+    const confirmed = await rig.client.callTool({
+      name: 'meta_confirm_action',
+      arguments: { confirmation_id: payload.confirmation_id },
+    });
+    expect(confirmed.isError).not.toBe(true);
+    expect(parseText(confirmed.content)).toMatch(/status=200/);
+    expect(rig.fetchMock.mock.calls.length).toBeGreaterThan(0);
+
+    await rig.client.close();
+    await fs.rm(rig.uploadDir, { recursive: true, force: true });
   });
 
   it('confirmation_mode=off skips the gate entirely', async () => {


### PR DESCRIPTION
### Motivation
- The custom-registered `messenger_upload_images` handler performed local file reads and executed the Avito upload immediately and thus bypassed the runtime confirmation gate used by `defineTool()` in `all_destructive` mode.

### Description
- Import `requiresConfirmation` from `src/core/policy.ts` and route the upload registration through a confirmation-aware wrapper in `src/domains/messenger.ts` by adding `requiresConfirmation` to the imports and using it at call time.
- Split the existing inline upload logic into a deferred `executeUpload` function that performs validation, reads local files, builds `FormData`, and calls `ctx.client.request` only when actually executing the upload.
- Add an `uploadHandler` that checks `requiresConfirmation('write', ctx.config)`, and when needed creates a pending action via `ctx.pendingStore.create` that returns the same `{ requires_confirmation: true, confirmation_id: ... }` payload shape used by other destructive tools; otherwise it calls `executeUpload` immediately.
- Replace direct registration of the old inline handler with the new `uploadHandler` so the tool remains visible/functional but no longer bypasses confirmation.
- Add regression test support in `test/confirmation.test.ts` (`makeUploadRig` + `it('custom messenger_upload_images requires confirmation in all_destructive mode')`) that verifies the upload does not call out to Avito before confirmation and executes only after `meta_confirm_action`.

### Testing
- Ran `npm run build` and the TypeScript build completed successfully.
- Ran the confirmation test subset with `npm test -- --run test/confirmation.test.ts` and the new/modified tests passed (confirmation behaviour for `messenger_upload_images` verified). 
- Ran the full suite with manifest generation via `npm run generate:manifest && npm test && npm run lint` and all tests passed (`201 passed, 6 skipped`) and lint completed (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d0333e5c8324a89bb18cf0073ab5)