### PR TITLE
Fix production state migration before v1.2.0 deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,13 @@ jobs:
           AVITO_MCP_HTTP_HOST=127.0.0.1
           AVITO_MCP_HTTP_PORT=3101
           AVITO_MCP_HTTP_PUBLIC_URL=https://mcp.example.com
-          AVITO_MCP_HTTP_AUTH=bearer
-          AVITO_MCP_HTTP_AUTH_TOKEN=ci-only-bearer-token-at-least-32-bytes
+          AVITO_MCP_HTTP_AUTH=oauth
+          AVITO_MCP_OAUTH_OWNER_PASSWORD=ci-only-owner-password-at-least-32-bytes
+          AVITO_MCP_OAUTH_STORE_FILE=/var/lib/avito-mcp/oauth-state.json
+          AVITO_MCP_WEBHOOK_ENABLED=true
+          AVITO_MCP_WEBHOOK_SECRET=ci-webhook-secret-at-least-32-bytes
+          AVITO_MCP_WEBHOOK_PUBLIC_URL=https://mcp.example.com
+          AVITO_MCP_WEBHOOK_LOG_FILE=/var/lib/avito-mcp/webhook-events.jsonl
           EOF
 
           cleanup() {
@@ -164,6 +169,63 @@ jobs:
             rm -f .env .remote.env
           }
           trap cleanup EXIT
+
+          # Reject hostile legacy state without following or changing its targets.
+          sudo install -d -o root -g root -m 0700 /var/lib/avito-mcp
+          sudo ln -s /etc/passwd /var/lib/avito-mcp/unsafe-link
+          if sudo env PATH="$PATH" AVITO_MCP_SOURCE_ROOT="$GITHUB_WORKSPACE" \
+            bash deploy/install-services.sh --start; then
+            echo 'ERROR: state symlink unexpectedly migrated'
+            exit 1
+          fi
+          test "$(stat -c %U /etc/passwd)" = root
+          sudo rm -f /var/lib/avito-mcp/unsafe-link
+
+          sudo install -o root -g root -m 0600 /dev/null /var/tmp/avito-mcp-hardlink-target
+          sudo ln /var/tmp/avito-mcp-hardlink-target /var/lib/avito-mcp/unsafe-hardlink
+          if sudo env PATH="$PATH" AVITO_MCP_SOURCE_ROOT="$GITHUB_WORKSPACE" \
+            bash deploy/install-services.sh --start; then
+            echo 'ERROR: state hardlink unexpectedly migrated'
+            exit 1
+          fi
+          test "$(stat -c %U /var/tmp/avito-mcp-hardlink-target)" = root
+          sudo rm -f /var/lib/avito-mcp/unsafe-hardlink /var/tmp/avito-mcp-hardlink-target
+
+          # Reproduce the production root-to-service-user ownership migration.
+          sudo install -o root -g root -m 0600 /dev/null \
+            /var/lib/avito-mcp/webhook-events.jsonl
+          printf '{"legacy":true}\n' | sudo tee \
+            /var/lib/avito-mcp/webhook-events.jsonl >/dev/null
+          legacy_state_hash="$(sudo sha256sum /var/lib/avito-mcp/webhook-events.jsonl | cut -d ' ' -f 1)"
+
+          # Run a real active legacy root unit so the installer must quiesce it,
+          # migrate its open persistent stores, and preserve rollback behavior.
+          sudo tee /etc/systemd/system/avito-mcp.service >/dev/null <<EOF
+          [Unit]
+          Description=legacy avito-mcp CI fixture
+          [Service]
+          Type=simple
+          WorkingDirectory=$GITHUB_WORKSPACE
+          EnvironmentFile=$GITHUB_WORKSPACE/.remote.env
+          Environment=AVITO_ENV_FILE=$GITHUB_WORKSPACE/.env
+          ExecStart=/usr/local/bin/node $GITHUB_WORKSPACE/dist/server.js
+          User=root
+          EOF
+          sudo systemctl daemon-reload
+          sudo systemctl start avito-mcp.service
+          curl --retry 10 --retry-delay 1 --retry-connrefused --fail --silent \
+            --connect-timeout 1 --max-time 3 http://127.0.0.1:3101/readyz | grep -q '"ok":true'
+          test "$(systemctl show avito-mcp.service --property=User --value)" = root
+
+          if sudo env PATH="$PATH" AVITO_MCP_SOURCE_ROOT="$GITHUB_WORKSPACE" \
+            AVITO_MCP_DEPLOY_HEALTH_URL=http://127.0.0.1:3199 \
+            bash deploy/install-services.sh --start; then
+            echo 'ERROR: unreachable readiness probe unexpectedly succeeded'
+            exit 1
+          fi
+          test "$(systemctl show avito-mcp.service --property=User --value)" = root
+          curl --retry 10 --retry-delay 1 --retry-connrefused --fail --silent \
+            --connect-timeout 1 --max-time 3 http://127.0.0.1:3101/readyz | grep -q '"ok":true'
 
           sudo env PATH="$PATH" AVITO_MCP_SOURCE_ROOT="$GITHUB_WORKSPACE" \
             bash deploy/install-services.sh --start
@@ -177,6 +239,34 @@ jobs:
           sudo -u avito-mcp test -x /opt/avito-mcp/current
           sudo -u avito-mcp test -r /opt/avito-mcp/current/package.json
           sudo -u avito-mcp test ! -w /opt/avito-mcp/current/dist/server.js
+          test "$(sudo stat -c %U:%G /var/lib/avito-mcp/webhook-events.jsonl)" = avito-mcp:avito-mcp
+          test "$(sudo stat -c %a /var/lib/avito-mcp/webhook-events.jsonl)" = 600
+          sudo -u avito-mcp test -r /var/lib/avito-mcp/webhook-events.jsonl
+          sudo -u avito-mcp test -w /var/lib/avito-mcp/webhook-events.jsonl
+          test "$(sudo sha256sum /var/lib/avito-mcp/webhook-events.jsonl | cut -d ' ' -f 1)" = "$legacy_state_hash"
+          test "$(systemctl show avito-mcp.service --property=User --value)" = avito-mcp
+
+          curl --fail --silent --show-error \
+            -H 'Content-Type: application/json' \
+            --data '{"id":"ci-event","payload":{"type":"message","value":{"chat_id":"ci"}}}' \
+            http://127.0.0.1:3101/avito/webhook/ci-webhook-secret-at-least-32-bytes \
+            >/tmp/webhook-response.json
+          curl --fail --silent --show-error \
+            -H 'Content-Type: application/json' \
+            -H 'Origin: https://mcp.example.com' \
+            --data '{"redirect_uris":["https://client.example/callback"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"scope":"avito:mcp"}' \
+            http://127.0.0.1:3101/register >/tmp/dcr-response.json
+          persisted=0
+          for _ in $(seq 1 30); do
+            if sudo test -s /var/lib/avito-mcp/oauth-state.json && \
+              [[ "$(sudo sha256sum /var/lib/avito-mcp/webhook-events.jsonl | cut -d ' ' -f 1)" != "$legacy_state_hash" ]]; then
+              persisted=1
+              break
+            fi
+            sleep 1
+          done
+          test "$persisted" = 1
+          test "$(sudo stat -c %U:%G /var/lib/avito-mcp/oauth-state.json)" = avito-mcp:avito-mcp
           if sudo grep -q 'must-not-enter-service-env' /etc/avito-mcp/avito-mcp.env; then
             echo 'ERROR: non-runtime secret entered the systemd environment'
             exit 1
@@ -192,6 +282,7 @@ jobs:
           curl --retry 10 --retry-delay 1 --retry-connrefused --fail --silent \
             --connect-timeout 1 --max-time 3 http://127.0.0.1:3101/readyz | grep -q '"ok":true'
 
+          state_hash="$(sudo sha256sum /var/lib/avito-mcp/webhook-events.jsonl | cut -d ' ' -f 1)"
           cat >.remote.env <<'EOF'
           AVITO_MCP_TRANSPORT=http
           AVITO_MCP_HTTP_HOST=127.0.0.1
@@ -207,6 +298,8 @@ jobs:
           fi
           curl --retry 10 --retry-delay 1 --retry-connrefused --fail --silent \
             --connect-timeout 1 --max-time 3 http://127.0.0.1:3101/readyz | grep -q '"ok":true'
+          test "$(sudo sha256sum /var/lib/avito-mcp/webhook-events.jsonl | cut -d ' ' -f 1)" = "$state_hash"
+          test "$(sudo stat -c %U:%G /var/lib/avito-mcp)" = avito-mcp:avito-mcp
 
       - name: Verify deployment artifacts
         run: |

--- a/deploy/install-services.sh
+++ b/deploy/install-services.sh
@@ -10,11 +10,17 @@ RELEASES_DIR=$INSTALL_ROOT/releases
 CURRENT_LINK=$INSTALL_ROOT/current
 CONFIG_DIR=/etc/avito-mcp
 SERVICE_ENV=$CONFIG_DIR/avito-mcp.env
+STATE_DIR=/var/lib/avito-mcp
 HEALTH_BASE_URL=${AVITO_MCP_DEPLOY_HEALTH_URL:-}
 START_SERVICES=0
 STAGING_DIR=
 READY_FILE=
 BACKUP_DIR=
+STATE_CREATED=0
+STATE_FROZEN=0
+STATE_ORIGINAL_UID=
+STATE_ORIGINAL_GID=
+STATE_ORIGINAL_MODE=
 TRANSACTION_ACTIVE=0
 caddy_managed=0
 
@@ -87,7 +93,123 @@ ensure_user() {
   if ! id -u "$user" >/dev/null 2>&1; then
     useradd --system --gid "$user" --home-dir "$home" --shell /usr/sbin/nologin "$user"
   fi
+}
+
+prepare_private_home() {
+  local user=$1
+  local home=$2
+  if [[ -L "$home" || ( -e "$home" && ! -d "$home" ) ]]; then
+    printf 'Unsafe service home: %s\n' "$home" >&2
+    return 1
+  fi
   install -d -o "$user" -g "$user" -m 0700 "$home"
+}
+
+validate_private_state() {
+  local user=$1
+  local state_dir=$2
+  local allow_root=$3
+  local app_uid app_gid entries state_dev path dev mode links uid gid type
+
+  app_uid=$(id -u "$user")
+  app_gid=$(id -g "$user")
+  state_dev=$(stat -c %d -- "$state_dir")
+  entries=$BACKUP_DIR/state.entries
+  find -P "$state_dir" -xdev -print0 >"$entries"
+  while IFS= read -r -d '' path; do
+    IFS=: read -r dev mode links uid gid < <(stat -c '%d:%f:%h:%u:%g' -- "$path")
+    type=$((16#$mode & 0170000))
+    if [[ "$dev" != "$state_dev" ]]; then
+      printf 'Application state has a foreign device\n' >&2
+      return 1
+    fi
+    if [[ $allow_root -eq 1 ]]; then
+      if [[ ! ( "$uid" == 0 || "$uid" == "$app_uid" ) || \
+        ! ( "$gid" == 0 || "$gid" == "$app_gid" ) ]]; then
+        printf 'Application state has a foreign owner\n' >&2
+        return 1
+      fi
+    elif [[ "$uid" != "$app_uid" || "$gid" != "$app_gid" ]]; then
+      printf 'Application state ownership migration is incomplete\n' >&2
+      return 1
+    fi
+    case "$type" in
+      16384) ;;
+      32768)
+        if [[ "$links" != 1 ]]; then
+          printf 'Application state contains a hard-linked file\n' >&2
+          return 1
+        fi
+        ;;
+      *)
+        printf 'Application state contains a symlink or special file\n' >&2
+        return 1
+        ;;
+    esac
+  done <"$entries"
+}
+
+migrate_private_state() {
+  local user=$1
+  local state_dir=$2
+  local app_uid app_gid mount_match
+
+  if [[ -L "$state_dir" || ( -e "$state_dir" && ! -d "$state_dir" ) ]]; then
+    printf 'Unsafe application state path: %s\n' "$state_dir" >&2
+    return 1
+  fi
+  if [[ ! -e "$state_dir" ]]; then
+    STATE_CREATED=1
+    install -d -o root -g root -m 0700 "$state_dir"
+  fi
+
+  # Recursive ownership must never cross an exact/nested mount or touch an
+  # inode outside the dedicated state filesystem.
+  if ! mount_match=$(awk -v root="$state_dir" \
+    '$5 == root || index($5, root "/") == 1 { print "mounted"; exit }' \
+    /proc/self/mountinfo); then
+    printf 'Unable to validate application state mounts\n' >&2
+    return 1
+  fi
+  if [[ -n "$mount_match" ]]; then
+    printf 'Application state tree contains a mount: %s\n' "$state_dir" >&2
+    return 1
+  fi
+
+  app_uid=$(id -u "$user")
+  app_gid=$(id -g "$user")
+  STATE_ORIGINAL_UID=$(stat -c %u -- "$state_dir")
+  STATE_ORIGINAL_GID=$(stat -c %g -- "$state_dir")
+  STATE_ORIGINAL_MODE=$(stat -c %a -- "$state_dir")
+  if [[ ! ( "$STATE_ORIGINAL_UID" == 0 || "$STATE_ORIGINAL_UID" == "$app_uid" ) || \
+    ! ( "$STATE_ORIGINAL_GID" == 0 || "$STATE_ORIGINAL_GID" == "$app_gid" ) ]]; then
+    printf 'Application state has a foreign owner\n' >&2
+    return 1
+  fi
+
+  # systemctl stop quiesces the service cgroup. Freezing the top directory before
+  # the recursive scan also blocks new pathname access; processes outside that
+  # cgroup with a pre-opened dirfd are outside the deployment trust boundary.
+  STATE_FROZEN=1
+  chown root:root "$state_dir"
+  chmod 0700 "$state_dir"
+  validate_private_state "$user" "$state_dir" 1
+
+  find -P "$state_dir" -xdev -mindepth 1 \
+    -exec chown --no-dereference "$app_uid:$app_gid" {} +
+  find -P "$state_dir" -xdev -mindepth 1 -type d -exec chmod 0700 {} +
+  find -P "$state_dir" -xdev -mindepth 1 -type f -exec chmod 0600 {} +
+
+  # Change the top directory last. A crash before this point leaves root as the
+  # owner, so StateDirectory= completes any partial recursive migration on boot.
+  chown "$app_uid:$app_gid" "$state_dir"
+  chmod 0700 "$state_dir"
+  validate_private_state "$user" "$state_dir" 0
+
+  # Ownership-only migration is compatible with both the legacy root unit and
+  # the hardened service user, so content is never rolled back or replaced.
+  STATE_FROZEN=0
+  STATE_CREATED=0
 }
 
 restore_file() {
@@ -104,6 +226,18 @@ rollback_release() {
   [[ $TRANSACTION_ACTIVE -eq 1 ]] || return 0
   TRANSACTION_ACTIVE=0
   set +e
+
+  # Stop the new process before restoring unit files/current release.
+  systemctl stop avito-mcp.service >/dev/null 2>&1
+  if [[ $STATE_CREATED -eq 1 ]]; then
+    rm -rf --one-file-system -- "$STATE_DIR"
+    STATE_CREATED=0
+  fi
+  if [[ $STATE_FROZEN -eq 1 && -d "$STATE_DIR" ]]; then
+    chown "$STATE_ORIGINAL_UID:$STATE_ORIGINAL_GID" "$STATE_DIR"
+    chmod "$STATE_ORIGINAL_MODE" "$STATE_DIR"
+    STATE_FROZEN=0
+  fi
 
   restore_file "$had_app_unit" "$BACKUP_DIR/avito-mcp.service" \
     /etc/systemd/system/avito-mcp.service
@@ -144,7 +278,7 @@ rollback_release() {
 
 on_error() {
   local status=$?
-  trap - ERR
+  trap - ERR HUP INT TERM
   rollback_release
   exit "$status"
 }
@@ -162,7 +296,7 @@ trap 'on_signal 129' HUP
 trap 'on_signal 130' INT
 trap 'on_signal 143' TERM
 
-ensure_user avito-mcp /var/lib/avito-mcp
+ensure_user avito-mcp "$STATE_DIR"
 install -d -o root -g root -m 0755 "$INSTALL_ROOT" "$RELEASES_DIR"
 
 # A version is immutable once installed. Re-running the installer reuses the
@@ -233,6 +367,7 @@ install -o root -g root -m 0644 \
 if [[ -x /usr/local/bin/caddy && -f "$SOURCE_ROOT/deploy/Caddyfile" ]]; then
   caddy_managed=1
   ensure_user caddy /var/lib/caddy
+  prepare_private_home caddy /var/lib/caddy
   if [[ -d /root/.local/share/caddy && ! -e /var/lib/caddy/.local/share/caddy ]]; then
     install -d -o caddy -g caddy -m 0700 /var/lib/caddy/.local/share
     cp -a /root/.local/share/caddy /var/lib/caddy/.local/share/caddy
@@ -250,6 +385,13 @@ if [[ $caddy_managed -eq 1 ]]; then
   systemd-analyze verify /etc/systemd/system/caddy.service
   /usr/local/bin/caddy validate --config /etc/caddy/avito-mcp.Caddyfile --adapter caddyfile
 fi
+
+# Freeze the legacy writer before validating and migrating its state ownership.
+# systemctl still has the old unit definition because daemon-reload happens below.
+if [[ $app_was_active -eq 1 ]]; then
+  systemctl stop avito-mcp.service
+fi
+migrate_private_state avito-mcp "$STATE_DIR"
 systemctl daemon-reload
 
 # Switch only after config, units, and release layout pass static validation.
@@ -258,8 +400,10 @@ rm -f -- "$next_link"
 ln -s "$release_dir" "$next_link"
 mv -Tf "$next_link" "$CURRENT_LINK"
 
-if [[ ${START_SERVICES} -eq 1 ]]; then
-  systemctl enable avito-mcp.service
+start_app=$START_SERVICES
+if [[ $app_was_active -eq 1 ]]; then start_app=1; fi
+if [[ $start_app -eq 1 ]]; then
+  if [[ $START_SERVICES -eq 1 ]]; then systemctl enable avito-mcp.service; fi
   systemctl restart avito-mcp.service
 
   READY_FILE=$(mktemp)
@@ -288,12 +432,14 @@ if [[ ${START_SERVICES} -eq 1 ]]; then
     false
   fi
 
-  if [[ $caddy_managed -eq 1 ]]; then
-    systemctl enable caddy.service
+  if [[ $caddy_managed -eq 1 && ( $START_SERVICES -eq 1 || $caddy_was_active -eq 1 ) ]]; then
+    if [[ $START_SERVICES -eq 1 ]]; then systemctl enable caddy.service; fi
     systemctl restart caddy.service
   fi
 fi
 
 TRANSACTION_ACTIVE=0
+STATE_CREATED=0
+STATE_FROZEN=0
 printf 'Immutable release %s installed at %s (start=%s)\n' \
   "$version" "$release_dir" "$START_SERVICES"

--- a/deploy/render-service-env.mjs
+++ b/deploy/render-service-env.mjs
@@ -2,6 +2,7 @@
 import { createRequire } from 'node:module';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { isIP } from 'node:net';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 
 const [packageJson, baseEnv, remoteEnv, outputFile] = process.argv.slice(2);
 if (!packageJson || !baseEnv || !remoteEnv || !outputFile) {
@@ -41,6 +42,27 @@ for (const key of [
   delete merged[key];
 }
 [merged.Client_id, merged.Client_secret, merged.Profile_id] = credentials;
+
+const serviceStateDirectory = '/var/lib/avito-mcp';
+for (const key of [
+  'AVITO_TOKEN_FILE',
+  'AVITO_MCP_OAUTH_STORE_FILE',
+  'AVITO_MCP_WEBHOOK_LOG_FILE',
+]) {
+  const value = merged[key];
+  if (typeof value !== 'string' || value === '') continue;
+  const resolved = resolve(value);
+  const rel = relative(serviceStateDirectory, resolved);
+  if (
+    !isAbsolute(value) ||
+    rel === '' ||
+    rel === '..' ||
+    rel.startsWith(`..${sep}`) ||
+    isAbsolute(rel)
+  ) {
+    throw new Error(`${key} must be an absolute file path inside ${serviceStateDirectory}`);
+  }
+}
 
 const exactKeys = new Set([
   'Client_id',

--- a/test/deploy-env.test.ts
+++ b/test/deploy-env.test.ts
@@ -38,7 +38,7 @@ describe('systemd deployment environment renderer', () => {
   it('parses dotenv syntax, allowlists runtime keys, and keeps remote overrides', async () => {
     const { result, output } = await render(
       'Client_id = "client id"\nClient_secret = "secret value"\nProfile_id = 123\nNPM_TOKEN=publish-canary\n',
-      'AVITO_MCP_TRANSPORT = http\nAVITO_MCP_HTTP_HOST=0.0.0.0\nAVITO_MCP_HTTP_PORT=3456\nLOG_LEVEL=warn\nNPM_CONFIG_USERCONFIG=/secret/npmrc\n',
+      'AVITO_MCP_TRANSPORT = http\nAVITO_MCP_HTTP_HOST=0.0.0.0\nAVITO_MCP_HTTP_PORT=3456\nLOG_LEVEL=warn\nAVITO_TOKEN_FILE=/var/lib/avito-mcp/token.json\nAVITO_MCP_OAUTH_STORE_FILE=/var/lib/avito-mcp/oauth.json\nAVITO_MCP_WEBHOOK_LOG_FILE=/var/lib/avito-mcp/webhook.jsonl\nNPM_CONFIG_USERCONFIG=/secret/npmrc\n',
     );
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toBe('http://127.0.0.1:3456');
@@ -50,10 +50,31 @@ describe('systemd deployment environment renderer', () => {
       Profile_id: '123',
       AVITO_MCP_TRANSPORT: 'http',
       LOG_LEVEL: 'warn',
+      AVITO_TOKEN_FILE: '/var/lib/avito-mcp/token.json',
+      AVITO_MCP_OAUTH_STORE_FILE: '/var/lib/avito-mcp/oauth.json',
+      AVITO_MCP_WEBHOOK_LOG_FILE: '/var/lib/avito-mcp/webhook.jsonl',
     });
     expect(raw).not.toContain('publish-canary');
     expect(raw).not.toContain('NPM_CONFIG_USERCONFIG');
     if (process.platform !== 'win32') expect((await fs.stat(output)).mode & 0o077).toBe(0);
+
+    for (const [key, value] of [
+      ['AVITO_TOKEN_FILE', '/tmp/outside-state'],
+      ['AVITO_MCP_OAUTH_STORE_FILE', 'relative-state.json'],
+      ['AVITO_MCP_WEBHOOK_LOG_FILE', '/var/lib/avito-mcp/../outside-state'],
+      ['AVITO_MCP_WEBHOOK_LOG_FILE', '/var/lib/avito-mcp'],
+    ]) {
+      await fs.rm(cleanupRoot!, { recursive: true, force: true });
+      cleanupRoot = undefined;
+      const invalid = await render(
+        'Client_id=id\nClient_secret=secret\nProfile_id=100\n',
+        `${key}=${value}\n`,
+      );
+      expect(invalid.result.status).not.toBe(0);
+      expect(invalid.result.stderr).toContain(
+        `${key} must be an absolute file path inside /var/lib/avito-mcp`,
+      );
+    }
   });
 
   it('fails closed instead of deploying without the full credential tuple', async () => {

--- a/test/release-hardening.test.ts
+++ b/test/release-hardening.test.ts
@@ -52,6 +52,13 @@ describe('release and deployment hardening', () => {
     expect(installer).toContain('npm ci --prefix "$STAGING_DIR" --omit=dev');
     expect(installer).toContain('chmod -R a+rX,a-w "$STAGING_DIR"');
     expect(installer).not.toContain('chmod -R a-w "$STAGING_DIR"');
+    expect(installer).toContain('migrate_private_state avito-mcp "$STATE_DIR"');
+    expect(installer).toContain('/proc/self/mountinfo');
+    expect(installer).toContain('Unable to validate application state mounts');
+    expect(installer).toContain("stat -c '%d:%f:%h:%u:%g'");
+    expect(installer).toContain('validate_private_state "$user" "$state_dir" 0');
+    expect(installer).toContain('content is never rolled back or replaced');
+    expect(installer).toContain('systemctl stop avito-mcp.service');
     expect(installer).toContain('rollback_release');
     expect(installer).not.toContain('app_was_active -eq 1 &&');
     expect(installer).not.toContain('caddy_was_active -eq 1 &&');
@@ -73,6 +80,11 @@ describe('release and deployment hardening', () => {
     expect(ci).toContain('deploy-gate:');
     expect(ci).toContain('bash deploy/install-services.sh --start');
     expect(ci).toContain('invalid redeploy unexpectedly succeeded');
+    expect(ci).toContain('state symlink unexpectedly migrated');
+    expect(ci).toContain('state hardlink unexpectedly migrated');
+    expect(ci).toContain('unreachable readiness probe unexpectedly succeeded');
+    expect(ci).toContain('AVITO_MCP_OAUTH_STORE_FILE=/var/lib/avito-mcp/oauth-state.json');
+    expect(ci).toContain('AVITO_MCP_WEBHOOK_LOG_FILE=/var/lib/avito-mcp/webhook-events.jsonl');
     expect(ci).toContain('systemctl restart avito-mcp.service');
     expect(ci).toContain('sudo -u avito-mcp test -x /opt/avito-mcp/current');
     expect(ci).toContain('PROJECT_AUDIT\\.md');


### PR DESCRIPTION
Closes the production preflight gap found after PR #24: legacy root-owned OAuth/webhook state was unreadable by the hardened avito-mcp service user.\n\nThis change adds fail-closed state-path validation, quiesced in-place ownership migration without replacing content, systemd path containment, and a deploy gate that exercises an active legacy root unit, forced rollback, OAuth persistence, webhook append, symlink/hardlink rejection, and final non-root readiness.\n\nLocal evidence: npm run verify:release passes 330/330 tests with release version consistency 1.2.0.