### PR TITLE
Release v1.3.0: durable reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,8 @@ Profile_id=
 #   all_destructive  — money, public И write требуют подтверждения
 #
 # Сам confirmation: tool возвращает {"requires_confirmation": true, "confirmation_id": "..."},
-# агент должен вызвать meta_confirm_action с этим id. Use is one-time. Pending state
-# хранится только in-memory и теряется при рестарте сервера.
+# агент должен вызвать meta_confirm_action с этим id. Use is one-time. Начиная с
+# v1.3.0 pending state сохраняется в account-scoped runtime state и переживает restart.
 #
 # Важно: confirmation — это server-side two-step safety guard от случайного one-shot
 # выполнения и audit layer. Это НЕ криптографическая защита от автономного агента —
@@ -90,6 +90,10 @@ Profile_id=
 # Example: openssl rand -base64 32
 # AVITO_MCP_CONFIRMATION_SECRET=
 
+# v1.3.0: external approval. В режиме external инициатор не считается approver;
+# обязателен отдельный AVITO_MCP_CONFIRMATION_SECRET, недоступный инициатору.
+# AVITO_MCP_APPROVAL_MODE=self
+
 # Лимит размера ЛЮБОГО HTTP-ответа в MB (JSON/text/PDF/audio).
 # Если сервер заявит Content-Length больше — отказ до чтения. Если без header — отказ
 # после чтения по фактическому размеру. Default 20 MB.
@@ -106,9 +110,14 @@ Profile_id=
 # TTL idempotency ledger в секундах. Каждый destructive tool теперь принимает
 # опциональный idempotencyKey: повторный вызов с тем же ключом и теми же args в течение
 # TTL возвращает закешированный результат (idempotent_replay=true). Тот же ключ с другими
-# args вернёт IdempotencyConflictError. Ledger in-memory, теряется при рестарте.
+# args вернёт IdempotencyConflictError. Ledger persistent и общий между процессами.
 # Default 3600 (1 час).
 # AVITO_MCP_IDEMPOTENCY_TTL_SEC=3600
+
+# Приватная директория общего runtime state (idempotency, pending, rate limits).
+# Default: каталог runtime рядом с AVITO_TOKEN_FILE; namespace включает API origin,
+# client id и Profile_id. Файлы/директории создаются с режимами 0600/0700.
+# AVITO_MCP_RUNTIME_STATE_DIR=
 
 # Максимальное ожидание межпроцессного файл-lock'а при OAuth refresh, в миллисекундах.
 # Защищает от thundering-herd когда несколько процессов avito-mcp (cron, CLI, MCP-клиент)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-07-14
+
+**Reliability release for autonomous Avito agents.** The destructive-operation pipeline now has durable, account-scoped coordination across stdio processes; the generated contract surface exposes a reproducible schema hash; and BBIP purchases return a verified item-level outcome instead of trusting the order-level HTTP/status alone. Existing 1.x tool names remain unchanged (148 tools). The release gate passes **335 tests across 31 files** with **80.89% statements / 71.74% branches / 81.83% functions / 83.81% lines** coverage.
+
+### Reliability and safety
+
+- **Durable idempotency reservations.** Destructive calls reserve `(API origin + client id + profile id + tool + idempotency key)` in private runtime state before the upstream call. Completed results replay after process restart and in another stdio process. A process death between reservation and result leaves a fail-closed recovery record, preventing an automatic duplicate charge.
+- **Persistent pending approvals.** Pending payloads are stored with `0600` files below an account-isolated `0700` namespace and can be listed, cancelled, claimed once, and executed after a restart. `AVITO_MCP_RUNTIME_STATE_DIR` overrides the default state location next to the token cache.
+- **External approval mode.** `AVITO_MCP_APPROVAL_MODE=external` requires a strong `AVITO_MCP_CONFIRMATION_SECRET`; the secret-provider approval identity is distinct from the initiating MCP principal. Existing `self` mode remains the default for compatibility.
+- **Cross-process endpoint limiter.** Avito `X-RateLimit-*` observations and local request reservations are shared by account/credential namespace and method/path. `meta_get_rate_limits` reads the shared view. Existing bounded 429/5xx backoff and `Retry-After` handling remain in place.
+- **Reusable backend topology.** The existing Streamable HTTP `http`/`both` transport is documented and reported by `meta_capabilities` as the long-lived shared backend: sessions reuse one Avito client, token store, limiter and state stores, with bounded sessions and idle cleanup. stdio remains the default.
+
+### Contracts and results
+
+- Fixed `items_post_account_spendings.spendingTypes` to the bundled Avito contract: `all`, `promotion`, `presence`, `commission`, `rest`; prompts now use the same values.
+- Removed the false `calls` claim from `items_post_item_stats_shallow`; supported fields are exactly `views`, `uniqViews`, `contacts`, `uniqContacts`, `favorites`, `uniqFavorites`, with calls delegated to `items_post_calls_stats`.
+- BBIP creation now polls the remote order and normalizes every item into `success`, `partial`, `failed`, `pending`, or `unknown`. Accepted/failed item ids and confirmed kopeck cost are separate; conflicting services expose `PROMOTION_CONFLICT`.
+- Generated manifest schema revision 2 includes every tool input schema plus a SHA-256 `schema_hash`. `meta_capabilities` now returns that hash, account fingerprint, active availability/risk metadata, approval/storage features, and explicit BBIP/wallet money units.
+- Structured errors add stable `code`, `http_status`, and `retry_after_seconds` fields while retaining the 1.x `type`, `httpStatus`, and `retryAfter` aliases.
+
+### Compatibility and upgrade
+
+- No tools were added, removed, or renamed. Existing configurations default to the previous approval behavior.
+- Runtime state is enabled by default. Operators running several credential sets must keep distinct `Client_id`/`Profile_id` values; the server derives isolated namespaces automatically. State files may contain destructive request/result data and must remain private.
+- Portfolio cursor tools, business snapshots, ID bridge, economics adapters, and a dedicated Unix-socket stdio shim remain planned for 1.4.x; they are intentionally not represented as completed in this release.
+
 ## [1.2.0] - 2026-07-10
 
 **End-to-end audit remediation release.** A multi-agent review covered the token client, destructive-operation pipeline, OAuth 2.1/HTTP transport, webhook receiver, all bundled OpenAPI contracts, tests, packaging, CI, Docker and systemd deployment. The implementation was then cross-reviewed with deterministic race reproductions. The resulting suite has **331 tests** across 30 files; whole-source coverage is **82.32% statements / 72.79% branches / 83.59% functions / 85.04% lines**. The manifest remains 148 tools, with corrected risk totals: `read:80 / write:40 / money:9 / public:16 / sensitive:3`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <a href="https://glama.ai/mcp/servers/elchin92/avito-mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/elchin92/avito-mcp/badges/card.svg" alt="avito-mcp MCP server" /></a>
 
-> **New in v1.2.0** — full security and contract hardening: account-bound tokens, mutation-safe retries, strict OAuth scope/resource and session ownership, operator-locked webhooks, race-safe confirmation/idempotency, descriptor-safe uploads, bounded response/state stores, all-source coverage, and generated OpenAPI contract checks for all 138 endpoint wrappers. See the [CHANGELOG](./CHANGELOG.md) for migration notes.
+> **New in v1.3.0** — durable account-scoped idempotency and pending approvals shared by stdio processes, a shared endpoint limiter, external approval mode, BBIP item-level terminal outcomes, generated schema hashes, and corrected spendings/shallow-stat contracts. See the [CHANGELOG](./CHANGELOG.md) for migration notes.
 
 ---
 
@@ -286,13 +286,13 @@ You can flip the default for the entire server: `AVITO_MCP_DRY_RUN_DEFAULT=true`
 
 ### Idempotency
 
-Every destructive tool also accepts an optional `idempotencyKey: string`. The server keeps an in-memory ledger keyed by bounded SHA-256 fingerprints of `(tool, key)` plus `hash(args)`; long keys are never retained verbatim:
+Every destructive tool also accepts an optional `idempotencyKey: string`. The server keeps a durable account-scoped ledger keyed by bounded SHA-256 fingerprints of `(tool, key)` plus `hash(args)`; long keys are never retained verbatim:
 
 - First call with a key: executes, caches the result.
 - Repeat call with the same key + identical args within TTL: returns the cached result, marked `structuredContent.idempotent_replay: true`. No second HTTP call.
 - Repeat call with the same key + different args: returns a structured `IdempotencyConflictError` (the dedupe contract was violated).
 
-This is the simplest reliable defence against duplicate sends after retries, crashes, or race conditions between concurrent agents. TTL via `AVITO_MCP_IDEMPOTENCY_TTL_SEC` (default 1 hour).
+The reservation is written before the upstream mutation. A completed result replays after restart and across stdio processes; an abandoned reservation fails closed for remote reconciliation instead of repeating a possibly charged action. TTL via `AVITO_MCP_IDEMPOTENCY_TTL_SEC` (default 1 hour), storage via `AVITO_MCP_RUNTIME_STATE_DIR`.
 
 ### Structured error taxonomy
 
@@ -792,7 +792,7 @@ Also out of scope: the `authorization_code` OAuth flow against Avito itself (no 
 - **Three-layer safety model** (every layer opt-in via env vars; the defaults keep trivial reads frictionless but harden everything destructive):
   - **`AVITO_MCP_MODE`** (`read_only` / `guarded` / `full_access`) — registration-time gate. Hidden tools never appear in `tools/list`. `read_only` exposes 80 tools, `guarded` exposes 120, and `full_access` exposes 145 ordinary tools (plus the 3 explicitly opt-in sensitive tools).
   - **`AVITO_MCP_ALLOW_TOOLS` / `AVITO_MCP_DENY_TOOLS`** — per-tool gating. Deny wins over allow.
-  - **`AVITO_MCP_CONFIRMATION_MODE`** (`off` / `money_public` (default) / `all_destructive`) — runtime gate. Destructive tools return `{requires_confirmation: true, confirmation_id: ...}`; the agent must call `meta_confirm_action` to execute. Pending state is in-memory, TTL'd (default 15 min), one-shot. `AVITO_MCP_CONFIRMATION_SECRET` upgrades this to **hard confirmation** — only a human who knows the secret can approve. Hard-confirm calls are limited to 20 per minute per authenticated principal; five wrong or missing secrets delete that pending action.
+  - **`AVITO_MCP_CONFIRMATION_MODE`** (`off` / `money_public` (default) / `all_destructive`) — runtime gate. Destructive tools return `{requires_confirmation: true, confirmation_id: ...}`; pending state is durable, account-scoped, TTL'd (default 15 min), and one-shot. `AVITO_MCP_CONFIRMATION_SECRET` enables hard confirmation; `AVITO_MCP_APPROVAL_MODE=external` additionally requires that secret-provider identity to differ from the initiator.
   - **`AVITO_MCP_EXPOSE_AUTH_TOOLS`** (default: `0`) — `auth_*` tools return OAuth tokens; classed as `sensitive` and hidden by default even in `full_access`.
   - **`AVITO_MCP_ALLOWED_UPLOAD_DIRS`** — `messenger_upload_images` reads files from disk; without an explicit directory allowlist it doesn't register at all. It opens and validates the same file descriptor, rejects parent/final symlink races, enforces file-count and aggregate-size limits, checks jpg/jpeg/png/webp magic bytes, and redacts local paths from errors.
 - Every tool is tagged with one of five risks (`sensitive: 3` / `read: 80` / `write: 40` / `money: 9` / `public: 16`), exposed as MCP `ToolAnnotations` and `_meta.risk`, and listed in [`dist/manifest.json`](./dist/manifest.json). The default `money_public` confirmation mode covers all externally visible, paid, and irreversible public actions, including webhook registration, blacklist changes, and CPA complaints.

--- a/README.ru.md
+++ b/README.ru.md
@@ -19,7 +19,7 @@
 
 <a href="https://glama.ai/mcp/servers/elchin92/avito-mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/elchin92/avito-mcp/badges/card.svg" alt="avito-mcp MCP server" /></a>
 
-> **Новое в v1.2.0** — полный security- и contract-hardening: token cache привязан к аккаунту, mutation-safe retry, строгие OAuth scope/resource и ownership сессий, webhook только на URL оператора, race-safe confirmation/idempotency, descriptor-safe upload, ограниченные response/state stores, coverage всего `src` и OpenAPI contract check всех 138 endpoint wrappers. Миграционные детали — в [CHANGELOG](./CHANGELOG.md).
+> **Новое в v1.3.0** — persistent account-scoped idempotency и pending approvals для нескольких stdio-процессов, общий endpoint limiter, external approval, item-level terminal outcome BBIP, schema hash и исправленные contracts spendings/shallow stats. Миграционные детали — в [CHANGELOG](./CHANGELOG.md).
 
 ---
 
@@ -286,13 +286,13 @@ Opt-in примитивы, чтобы пакет безопасно жил в **
 
 ### Idempotency
 
-Каждый destructive tool принимает опциональный `idempotencyKey: string`. Сервер хранит in-memory ledger по bounded SHA-256 fingerprint от `(tool, key)` и `hash(args)`; длинные ключи не сохраняются дословно:
+Каждый destructive tool принимает опциональный `idempotencyKey: string`. Сервер хранит persistent account-scoped ledger по bounded SHA-256 fingerprint от `(tool, key)` и `hash(args)`; длинные ключи не сохраняются дословно:
 
 - Первый вызов: исполнение, кеш результата.
 - Повтор с тем же ключом и теми же args в течение TTL: возвращается кеш с пометкой `structuredContent.idempotent_replay: true`. Второй HTTP-вызов НЕ делается.
 - Повтор с тем же ключом и ДРУГИМИ args: structured-ошибка `IdempotencyConflictError` (нарушен контракт дедупа).
 
-Простейшая надёжная защита от дублей при retries, crashes, race conditions между параллельными агентами. TTL — `AVITO_MCP_IDEMPOTENCY_TTL_SEC` (default 1 час).
+Reservation записывается до upstream mutation. Завершённый результат replay-ится после restart и между stdio-процессами; брошенная reservation fail-closed требует remote reconciliation и не повторяет потенциальное списание. TTL — `AVITO_MCP_IDEMPOTENCY_TTL_SEC`, storage — `AVITO_MCP_RUNTIME_STATE_DIR`.
 
 ### Структурированная таксономия ошибок
 
@@ -792,7 +792,7 @@ Settings → MCP Servers → Add. Поля UI: name `avito`, command `npx`, args
 - **Три слоя безопасности** (каждый opt-in через env vars; defaults не мешают тривиальным чтениям, но харднят всё destructive):
   - **`AVITO_MCP_MODE`** (`read_only` / `guarded` / `full_access`) — фильтр на регистрации. Скрытые tools не появляются в `tools/list`. `read_only` отдаёт 80 tools, `guarded` — 120, `full_access` — 145 обычных tools (плюс 3 sensitive только по явному opt-in).
   - **`AVITO_MCP_ALLOW_TOOLS` / `AVITO_MCP_DENY_TOOLS`** — per-tool фильтр. Deny всегда побеждает allow.
-  - **`AVITO_MCP_CONFIRMATION_MODE`** (`off` / `money_public` (default) / `all_destructive`) — runtime gate. Destructive tools возвращают `{requires_confirmation: true, confirmation_id: ...}`; агент должен вызвать `meta_confirm_action` чтобы выполнить. Pending хранится in-memory, с TTL (default 15 мин), одноразовый. `AVITO_MCP_CONFIRMATION_SECRET` апгрейдит это до **hard confirmation** — подтвердить может только человек, знающий секрет. Hard-confirm ограничен 20 вызовами в минуту на аутентифицированного principal; пять неверных или отсутствующих секретов удаляют конкретный pending action.
+  - **`AVITO_MCP_CONFIRMATION_MODE`** (`off` / `money_public` (default) / `all_destructive`) — runtime gate. Pending state persistent, account-scoped, с TTL (default 15 мин) и one-shot. `AVITO_MCP_CONFIRMATION_SECRET` включает hard confirmation; `AVITO_MCP_APPROVAL_MODE=external` дополнительно отделяет secret-provider identity от инициатора.
   - **`AVITO_MCP_EXPOSE_AUTH_TOOLS`** (default: `0`) — `auth_*` tools возвращают OAuth токены; помечены как `sensitive` и скрыты по default даже в `full_access`.
   - **`AVITO_MCP_ALLOWED_UPLOAD_DIRS`** — `messenger_upload_images` читает файлы с диска; без явного списка директорий tool не регистрируется. Открывается и проверяется один descriptor, parent/final symlink race отклоняется, действуют лимиты количества и общего размера, magic-byte check jpg/jpeg/png/webp, локальные пути редактируются в ошибках.
 - Каждый tool помечен одной из пяти категорий риска (`sensitive: 3` / `read: 80` / `write: 40` / `money: 9` / `public: 16`), отдаётся клиенту как MCP `ToolAnnotations` и `_meta.risk`, плюс перечислен в [`dist/manifest.json`](./dist/manifest.json). Default `money_public` confirmation покрывает все внешне видимые, платные и необратимые public actions, включая webhook registration, blacklist и CPA complaints.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -105,7 +105,7 @@ This is the closest to the v0.1.x default behaviour. **Don't use this for unatte
 
 ## On the confirmation flow — what it is and isn't
 
-The confirmation flow (`AVITO_MCP_CONFIRMATION_MODE != off`) is a **server-side two-step safety guard against accidental one-shot execution**. It's also an **audit layer** — every destructive action shows up as a pending entry, and there's a paper trail.
+The confirmation flow (`AVITO_MCP_CONFIRMATION_MODE != off`) is a **server-side two-step safety guard against accidental one-shot execution**. Pending actions and idempotency results are durable and account-scoped. Set `AVITO_MCP_APPROVAL_MODE=external` together with a separate `AVITO_MCP_CONFIRMATION_SECRET` when the initiator must not self-approve.
 
 It is **not a cryptographic human-approval mechanism by itself.** An autonomous agent can theoretically:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "avito-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "avito-mcp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "avito-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "mcpName": "io.github.elchin92/avito-mcp",
-  "description": "Universal MCP server for the Avito API — 148 tools across 18 domains, safe-by-default with dry-run, idempotency, structured errors, MCP resources/prompts and cross-process token lock. Runs over stdio or a remote OAuth 2.1-secured HTTP endpoint, with a built-in Avito webhook receiver. Install via npx, plug into any MCP-compatible client.",
+  "description": "Universal MCP server for the Avito API — 148 tools across 18 domains, safe-by-default with dry-run, durable idempotency, external approval, shared rate limits and structured errors. Runs over stdio or a reusable OAuth 2.1-secured HTTP backend, with a built-in Avito webhook receiver.",
   "type": "module",
   "bin": {
     "avito-mcp": "dist/server.js"

--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -15,7 +15,7 @@ import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 
 import { AvitoClient } from '../src/core/client.js';
 import { domains } from '../src/meta/domain-registry.js';
@@ -111,6 +111,7 @@ async function main(): Promise<void> {
     accessesLocalFiles?: boolean;
     description: string;
     annotations: unknown;
+    inputSchema: unknown;
   }> = [];
 
   for (const t of tools) {
@@ -132,6 +133,7 @@ async function main(): Promise<void> {
       environment,
       description: t.description ?? '',
       annotations: t.annotations ?? null,
+      inputSchema: t.inputSchema,
     };
     // v0.6.0: title — an optional human-readable name.
     if (typeof t.title === 'string' && t.title.length > 0) entry.title = t.title;
@@ -142,8 +144,8 @@ async function main(): Promise<void> {
   for (const arr of Object.values(byDomain)) arr.sort();
   flat.sort((a, b) => (a.name < b.name ? -1 : 1));
 
-  const manifest = {
-    schema_version: 1,
+  const manifestBase = {
+    schema_version: 2,
     name: PACKAGE_NAME,
     version: VERSION,
     tool_count: tools.length,
@@ -160,6 +162,10 @@ async function main(): Promise<void> {
     by_domain: byDomain,
     tools: flat,
   };
+  const schemaHash = createHash('sha256')
+    .update(JSON.stringify(flat.map(({ name, risk, environment, inputSchema }) => ({ name, risk, environment, inputSchema }))))
+    .digest('hex');
+  const manifest = { ...manifestBase, schema_hash: schemaHash };
 
   mkdirSync(dirname(OUT_PATH), { recursive: true });
   writeFileSync(OUT_PATH, JSON.stringify(manifest, null, 2) + '\n', 'utf8');

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/elchin92/avito-mcp",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "1.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "avito-mcp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { config as loadDotenv } from 'dotenv';
 import { z } from 'zod';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 const envFile = process.env.AVITO_ENV_FILE ?? resolve(process.cwd(), '.env');
 loadDotenv({ path: envFile, quiet: true });
@@ -30,6 +30,7 @@ function defaultTokenFile(): string {
 
 export type SafetyMode = 'read_only' | 'guarded' | 'full_access';
 export type ConfirmationMode = 'off' | 'money_public' | 'all_destructive';
+export type ApprovalMode = 'self' | 'external';
 
 // ───────────────────────── v0.9.0: HTTP transport + webhook ─────────────────────────
 
@@ -251,12 +252,14 @@ const ConfigSchema = z.object({
     .string()
     .min(32, 'AVITO_MCP_CONFIRMATION_SECRET must be at least 32 characters')
     .optional(),
+  approvalMode: z.enum(['self', 'external']).default('self'),
   maxBinaryMb: z.number().int().positive().default(20),
   // v0.7.0 ───────────────────────────────────────────────────
   /** Default for `dryRun` parameter on write/money/public tools. */
   dryRunDefault: z.boolean().default(false),
   /** TTL for idempotency ledger entries, seconds. */
   idempotencyTtlSec: z.number().int().positive().default(3600),
+  runtimeStateDir: z.string().min(1),
   /** Max wait for cross-process token file lock, ms. */
   tokenLockTimeoutMs: z.number().int().positive().default(30_000),
 });
@@ -382,7 +385,12 @@ function buildWebhookConfig(httpPublicUrl: string): WebhookConfig {
   };
 }
 
-export type Config = z.infer<typeof ConfigSchema> & {
+type ParsedConfig = z.infer<typeof ConfigSchema>;
+export type Config = Omit<ParsedConfig, 'approvalMode' | 'runtimeStateDir'> & {
+  /** Optional in programmatic Config fixtures; environment-loaded config always sets it. */
+  approvalMode?: ApprovalMode;
+  /** Optional in programmatic Config fixtures; environment-loaded config always sets it. */
+  runtimeStateDir?: string;
   http: HttpConfig;
   webhook: WebhookConfig;
 };
@@ -420,6 +428,12 @@ function loadUnchecked(): Config {
       86_400,
     ),
     confirmationSecret: process.env.AVITO_MCP_CONFIRMATION_SECRET,
+    approvalMode: parseChoice(
+      process.env.AVITO_MCP_APPROVAL_MODE,
+      'self',
+      'AVITO_MCP_APPROVAL_MODE',
+      ['self', 'external'] as const,
+    ),
     maxBinaryMb: parsePositiveInt(
       process.env.AVITO_MCP_MAX_BINARY_MB,
       20,
@@ -438,6 +452,8 @@ function loadUnchecked(): Config {
       'AVITO_MCP_IDEMPOTENCY_TTL_SEC',
       604_800,
     ),
+    runtimeStateDir:
+      process.env.AVITO_MCP_RUNTIME_STATE_DIR?.trim() || join(dirname(defaultTokenFile()), 'runtime'),
     tokenLockTimeoutMs: parsePositiveInt(
       process.env.AVITO_MCP_TOKEN_LOCK_TIMEOUT_MS,
       30_000,
@@ -452,6 +468,11 @@ function loadUnchecked(): Config {
       .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
       .join('\n');
     throw new EnvValidationError(issues);
+  }
+  if (parsed.data.approvalMode === 'external' && !parsed.data.confirmationSecret) {
+    throw new EnvValidationError(
+      'AVITO_MCP_APPROVAL_MODE=external requires AVITO_MCP_CONFIRMATION_SECRET (at least 32 characters)',
+    );
   }
   // HTTP + webhook config are computed in JS because several defaults depend on
   // other fields. Syntax, bounds, and applicable secret requirements fail here;

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -14,6 +14,7 @@ import { TokenStore } from './token-store.js';
 import { RateLimiter, sleep } from './rate-limiter.js';
 import { buildUrl, type Primitive, type QueryValue } from './url.js';
 import { hasConfiguredCredentials } from './credentials.js';
+import { runtimeNamespace, runtimeStateDirectory } from './runtime-state.js';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 export type BodyContentType =
@@ -83,7 +84,7 @@ export const DEFAULT_RETRY: RetryConfig = {
 };
 
 export class AvitoClient {
-  readonly rateLimiter = new RateLimiter();
+  readonly rateLimiter: RateLimiter;
   readonly tokenStore: TokenStore;
   private readonly retry: RetryConfig;
 
@@ -91,6 +92,11 @@ export class AvitoClient {
     private readonly config: Config,
     opts: { retry?: Partial<RetryConfig> } = {},
   ) {
+    this.rateLimiter = new RateLimiter({
+      stateDir: runtimeStateDirectory(config),
+      namespace: runtimeNamespace(config),
+      lockTimeoutMs: config.tokenLockTimeoutMs,
+    });
     this.tokenStore = new TokenStore(
       config.tokenFile,
       () => this.fetchTokenViaClientCredentials(),
@@ -107,12 +113,13 @@ export class AvitoClient {
   async request<T = unknown>(opts: RequestOptions): Promise<RequestResponse<T>> {
     const url = buildUrl(this.config.baseUrl, opts.path, opts.pathParams, opts.query);
     const domain = opts.domain ?? extractDomain(opts.path);
+    const rateKey = `${domain}:${opts.method}:${opts.path}`;
     const reqInfo: RequestInfo = { method: opts.method, url, domain };
     const deadline = Date.now() + (opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
-    await this.awaitBeforeDeadline(this.rateLimiter.waitIfNeeded(domain), deadline, reqInfo);
+    await this.awaitBeforeDeadline(this.rateLimiter.waitIfNeeded(rateKey), deadline, reqInfo);
 
-    return this.doRequest<T>(opts, url, reqInfo, deadline);
+    return this.doRequest<T>(opts, url, reqInfo, deadline, rateKey);
   }
 
   private async doRequest<T>(
@@ -120,6 +127,7 @@ export class AvitoClient {
     url: string,
     reqInfo: RequestInfo,
     deadline: number,
+    rateKey: string,
   ): Promise<RequestResponse<T>> {
     let allowRefresh = true;
     let retries429 = 0;
@@ -144,7 +152,7 @@ export class AvitoClient {
             ? await fetchGetWithBody(url, requestInit, opts.allowGetBody === true)
             : await fetch(url, requestInit);
 
-        this.rateLimiter.observe(reqInfo.domain ?? 'default', resp.headers);
+        this.rateLimiter.observe(rateKey, resp.headers, reqInfo.domain ?? 'default');
 
         if (resp.status === 401 && allowRefresh && opts.auth !== false) {
           await discardResponse(resp);

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -83,6 +83,8 @@ export type ErrorType =
   | 'INTERNAL_ERROR';
 
 export interface ErrorEnvelope {
+  /** Stable machine-readable code. `type` is retained as a 1.x compatibility alias. */
+  code?: ErrorType | string;
   type: ErrorType;
   message: string;
   retryable: boolean;
@@ -146,8 +148,13 @@ export function errorToMcpContent(err: unknown): CallToolResult {
     // v0.7.0: new structure — `error: { type, message, retryable, ... }`.
     // The old error_kind field is kept for backwards-compat: code that read
     // structuredContent.error_kind in v0.6.0 will keep working.
-    structuredContent: {
-      error: envelope,
+  structuredContent: {
+      error: {
+        ...envelope,
+        code: envelope.code ?? envelope.type,
+        http_status: envelope.httpStatus,
+        retry_after_seconds: envelope.retryAfter ?? null,
+      },
       error_kind: legacyKindFromType(envelope.type),
     },
   };

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -16,7 +16,11 @@
  * We document this as an extension point.
  */
 import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { withFileLock } from './file-lock.js';
+import { readJsonFile, safeStatePart, writeJsonAtomic } from './runtime-state.js';
 
 export interface IdempotencyEntry {
   key: string;
@@ -30,6 +34,24 @@ export interface IdempotencyEntry {
 interface IdempotencyReservation {
   argsHash: string;
   promise: Promise<IdempotencyEntry>;
+}
+
+interface PersistentRecord {
+  version: 1;
+  state: 'in_flight' | 'completed';
+  key: string;
+  toolName: string;
+  argsHash: string;
+  createdAt: number;
+  expiresAt: number;
+  ownerPid?: number;
+  result?: CallToolResult;
+}
+
+export interface IdempotencyStoreOptions {
+  stateDir?: string;
+  namespace?: string;
+  lockTimeoutMs?: number;
 }
 
 export interface IdempotencyRetentionOptions {
@@ -58,6 +80,16 @@ export class IdempotencyLimitError extends Error {
   }
 }
 
+export class IdempotencyRecoveryRequiredError extends Error {
+  constructor(key: string, toolName: string) {
+    super(
+      `Idempotency key '${storedIdempotencyKey(key)}' for '${toolName}' has an unfinished durable reservation. ` +
+        'The previous process may have received an upstream result before it stopped. Refusing to repeat the action; reconcile the remote operation first.',
+    );
+    this.name = 'IdempotencyRecoveryRequiredError';
+  }
+}
+
 export class IdempotencyStore {
   private entries = new Map<string, IdempotencyEntry>();
   private reservations = new Map<string, IdempotencyReservation>();
@@ -69,10 +101,32 @@ export class IdempotencyStore {
   constructor(
     private readonly ttlMs: number,
     private readonly maxEntries: number = 10_000,
+    private readonly options: IdempotencyStoreOptions = {},
   ) {
     if (!Number.isSafeInteger(maxEntries) || maxEntries <= 0) {
       throw new RangeError('IdempotencyStore maxEntries must be a positive safe integer');
     }
+  }
+
+  async rememberPersistent(
+    key: string,
+    toolName: string,
+    argsHash: string,
+    result: CallToolResult,
+    options: IdempotencyRetentionOptions = {},
+  ): Promise<IdempotencyEntry> {
+    const entry = this.remember(key, toolName, argsHash, result, options);
+    const path = this.persistentPath(toolName, key);
+    if (path) {
+      await withFileLock(
+        path,
+        async () => {
+          await writeJsonAtomic(path, this.toPersistent(entry));
+        },
+        { timeoutMs: this.options.lockTimeoutMs ?? 30_000 },
+      );
+    }
+    return entry;
   }
 
   /**
@@ -134,6 +188,53 @@ export class IdempotencyStore {
     execute: () => Promise<CallToolResult>,
     options: IdempotencyRetentionOptions = {},
   ): Promise<{ entry: IdempotencyEntry; replay: boolean }> {
+    const persistentPath = this.persistentPath(toolName, key);
+    if (persistentPath) {
+      return withFileLock(
+        persistentPath,
+        async () => {
+          const record = await readJsonFile<PersistentRecord>(persistentPath);
+          const now = Date.now();
+          if (record && record.argsHash !== argsHash) {
+            throw new IdempotencyConflictError(key, toolName);
+          }
+          if (record?.state === 'completed' && record.result && record.expiresAt >= now) {
+            const entry = this.fromPersistent(record);
+            this.entries.set(this.composeKey(toolName, key), entry);
+            return { entry, replay: true };
+          }
+          if (record?.state === 'in_flight') {
+            throw new IdempotencyRecoveryRequiredError(key, toolName);
+          }
+          if (record) await fs.rm(persistentPath, { force: true });
+
+          const reservation: PersistentRecord = {
+            version: 1,
+            state: 'in_flight',
+            key: storedIdempotencyKey(key),
+            toolName,
+            argsHash,
+            createdAt: now,
+            expiresAt: now + this.ttlMs,
+            ownerPid: process.pid,
+          };
+          await writeJsonAtomic(persistentPath, reservation);
+          try {
+            const result = await execute();
+            const entry = this.remember(key, toolName, argsHash, result, options);
+            await writeJsonAtomic(persistentPath, this.toPersistent(entry));
+            return { entry, replay: false };
+          } catch (error) {
+            // A caught application failure means no usable result was produced. A hard
+            // process stop never reaches this branch, leaving the reservation fail-closed.
+            await fs.rm(persistentPath, { force: true });
+            throw error;
+          }
+        },
+        { timeoutMs: this.options.lockTimeoutMs ?? 30_000 },
+      );
+    }
+
     const composed = this.composeKey(toolName, key);
     this.cleanupExpired();
 
@@ -195,6 +296,32 @@ export class IdempotencyStore {
 
   private composeKey(toolName: string, key: string): string {
     return `${toolName}::${fingerprintIdempotencyKey(key)}`;
+  }
+
+  private persistentPath(toolName: string, key: string): string | undefined {
+    if (!this.options.stateDir || !this.options.namespace) return undefined;
+    return join(
+      this.options.stateDir,
+      this.options.namespace,
+      'idempotency',
+      safeStatePart(toolName),
+      `${fingerprintIdempotencyKey(key)}.json`,
+    );
+  }
+
+  private toPersistent(entry: IdempotencyEntry): PersistentRecord {
+    return { version: 1, state: 'completed', ...entry };
+  }
+
+  private fromPersistent(record: PersistentRecord): IdempotencyEntry {
+    return {
+      key: record.key,
+      toolName: record.toolName,
+      argsHash: record.argsHash,
+      createdAt: record.createdAt,
+      expiresAt: record.expiresAt,
+      result: record.result!,
+    };
   }
 
   private cleanupExpired(): void {

--- a/src/core/pending-actions.ts
+++ b/src/core/pending-actions.ts
@@ -1,7 +1,11 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
 
 import type { ToolRisk } from './tool-factory.js';
+import { withFileLock } from './file-lock.js';
+import { readJsonFile, writeJsonAtomic } from './runtime-state.js';
 
 /**
  * Executor function for a pending action. Returned within the pending action
@@ -18,6 +22,9 @@ export interface PendingAction {
   args: Record<string, unknown>;
   createdAt: number;
   expiresAt: number;
+  initiator: string;
+  idempotencyKey?: string;
+  argsHash?: string;
   execute: PendingExecutor;
 }
 
@@ -29,6 +36,7 @@ export interface PendingActionInfo {
   summary: string;
   createdAt: number;
   expiresAt: number;
+  initiator: string;
 }
 
 /**
@@ -84,11 +92,27 @@ export class PendingActionStore {
   private failedConfirmationAttempts = new Map<string, number>();
   private confirmationAttempts = new Map<string, number[]>();
   private listeners: PendingChangeListener[] = [];
+  private executors = new Map<
+    string,
+    (args: Record<string, unknown>, idempotencyKey?: string, argsHash?: string) => Promise<CallToolResult>
+  >();
 
   constructor(
     private readonly ttlMs: number,
     private readonly maxActions: number = 1000,
+    private readonly persistent?: { stateDir: string; namespace: string; lockTimeoutMs?: number },
   ) {}
+
+  registerExecutor(
+    toolName: string,
+    executor: (
+      args: Record<string, unknown>,
+      idempotencyKey?: string,
+      argsHash?: string,
+    ) => Promise<CallToolResult>,
+  ): void {
+    this.executors.set(toolName, executor);
+  }
 
   /**
    * Creates an entry. id is 32 hex characters (16 bytes of entropy), strong
@@ -99,6 +123,9 @@ export class PendingActionStore {
     risk: ToolRisk;
     summary: string;
     args: Record<string, unknown>;
+    initiator?: string;
+    idempotencyKey?: string;
+    argsHash?: string;
     execute: PendingExecutor;
   }): PendingAction {
     const now = Date.now();
@@ -109,6 +136,7 @@ export class PendingActionStore {
     const id = randomBytes(16).toString('hex');
     const action: PendingAction = {
       ...input,
+      initiator: input.initiator ?? 'session:local-stdio',
       id,
       createdAt: now,
       expiresAt: now + this.ttlMs,
@@ -118,10 +146,35 @@ export class PendingActionStore {
     return action;
   }
 
+  async createPersistent(input: Parameters<PendingActionStore['create']>[0]): Promise<PendingAction> {
+    const action = this.create(input);
+    const path = this.actionPath(action.id);
+    if (path) {
+      try {
+        await withFileLock(path, () => writeJsonAtomic(path, this.toRecord(action)), {
+          timeoutMs: this.persistent?.lockTimeoutMs ?? 30_000,
+        });
+      } catch (error) {
+        this.delete(action.id);
+        throw error;
+      }
+    }
+    return action;
+  }
+
   /** Returns the entry if it's alive. Otherwise undefined (the caller must report why itself). */
   get(id: string): PendingAction | undefined {
     this.cleanupExpired();
     return this.actions.get(id);
+  }
+
+  async getPersistent(id: string): Promise<PendingAction | undefined> {
+    const local = this.get(id);
+    if (local) return local;
+    const path = this.actionPath(id);
+    if (!path) return undefined;
+    const record = await readJsonFile<PersistentPendingRecord>(path);
+    return record ? this.rehydrate(record) : undefined;
   }
 
   /** Returns true if the entry existed and was removed, false if it never existed. */
@@ -131,6 +184,21 @@ export class PendingActionStore {
     this.failedConfirmationAttempts.delete(id);
     if (existed && had) this.emit('deleted', had);
     return existed;
+  }
+
+  async deletePersistent(id: string): Promise<boolean> {
+    const local = this.delete(id);
+    const path = this.actionPath(id);
+    if (!path) return local;
+    return withFileLock(
+      path,
+      async () => {
+        const existed = (await readJsonFile<PersistentPendingRecord>(path)) !== undefined;
+        await fs.rm(path, { force: true });
+        return local || existed;
+      },
+      { timeoutMs: this.persistent?.lockTimeoutMs ?? 30_000 },
+    );
   }
 
   /**
@@ -146,6 +214,34 @@ export class PendingActionStore {
     this.failedConfirmationAttempts.delete(id);
     this.emit('deleted', action);
     return action;
+  }
+
+  async takePersistent(id: string): Promise<PendingAction | undefined> {
+    const path = this.actionPath(id);
+    if (!path) return this.take(id);
+    return withFileLock(
+      path,
+      async () => {
+        const record = await readJsonFile<PersistentPendingRecord>(path);
+        if (!record) {
+          this.actions.delete(id);
+          return undefined;
+        }
+        const local = this.actions.get(id);
+        const action = local ?? this.rehydrate(record);
+        if (!action || action.expiresAt < Date.now()) {
+          await fs.rm(path, { force: true });
+          return undefined;
+        }
+        this.actions.delete(id);
+        this.inFlight.set(id, action);
+        this.failedConfirmationAttempts.delete(id);
+        await fs.rm(path, { force: true });
+        this.emit('deleted', action);
+        return action;
+      },
+      { timeoutMs: this.persistent?.lockTimeoutMs ?? 30_000 },
+    );
   }
 
   /**
@@ -221,6 +317,35 @@ export class PendingActionStore {
     return [...this.actions.values()].map(toInfo);
   }
 
+  async listPersistent(): Promise<PendingActionInfo[]> {
+    if (!this.persistent) return this.list();
+    const directory = join(this.persistent.stateDir, this.persistent.namespace, 'pending');
+    let names: string[];
+    try {
+      names = await fs.readdir(directory);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return this.list();
+      throw error;
+    }
+    const records = await Promise.all(
+      names.filter((name) => /^[0-9a-f]{32}\.json$/.test(name)).map((name) => readJsonFile<PersistentPendingRecord>(join(directory, name))),
+    );
+    const byId = new Map(this.list().map((item) => [item.id, item]));
+    for (const record of records) {
+      if (!record || record.expiresAt < Date.now()) continue;
+      byId.set(record.id, {
+        id: record.id,
+        toolName: record.toolName,
+        risk: record.risk,
+        summary: record.summary,
+        createdAt: record.createdAt,
+        expiresAt: record.expiresAt,
+        initiator: record.initiator,
+      });
+    }
+    return [...byId.values()];
+  }
+
   /** For tests — the current size. */
   size(): number {
     this.cleanupExpired();
@@ -255,6 +380,62 @@ export class PendingActionStore {
       }
     }
   }
+
+  private actionPath(id: string): string | undefined {
+    if (!this.persistent || !/^[0-9a-f]{32}$/.test(id)) return undefined;
+    return join(this.persistent.stateDir, this.persistent.namespace, 'pending', `${id}.json`);
+  }
+
+  private toRecord(action: PendingAction): PersistentPendingRecord {
+    return {
+      version: 1,
+      id: action.id,
+      toolName: action.toolName,
+      risk: action.risk,
+      summary: action.summary,
+      args: action.args,
+      createdAt: action.createdAt,
+      expiresAt: action.expiresAt,
+      initiator: action.initiator,
+      idempotencyKey: action.idempotencyKey,
+      argsHash: action.argsHash,
+    };
+  }
+
+  private rehydrate(record: PersistentPendingRecord): PendingAction | undefined {
+    if (record.version !== 1 || record.expiresAt < Date.now()) return undefined;
+    const executor = this.executors.get(record.toolName);
+    if (!executor) return undefined;
+    const action = { ...record } as Omit<PersistentPendingRecord, 'version'> & {
+      version?: number;
+    };
+    delete action.version;
+    return {
+      ...action,
+      execute: () => executor(record.args, record.idempotencyKey, record.argsHash),
+    };
+  }
+}
+
+interface PersistentPendingRecord extends Omit<PendingAction, 'execute'> {
+  version: 1;
+}
+
+export interface CallerExtra {
+  authInfo?: { clientId?: string };
+  sessionId?: string;
+  requestInfo?: { headers?: Record<string, string | string[] | undefined> };
+}
+
+export function callerPrincipal(extra: CallerExtra | undefined): string {
+  if (extra?.authInfo?.clientId) return `oauth:${extra.authInfo.clientId}`;
+  const raw = extra?.requestInfo?.headers?.authorization;
+  const authorization = Array.isArray(raw) ? raw[0] : raw;
+  const bearer = /^Bearer\s+(.+)$/i.exec(authorization ?? '')?.[1];
+  if (bearer) {
+    return `bearer:${createHash('sha256').update(bearer).digest('base64url')}`;
+  }
+  return `session:${extra?.sessionId ?? 'local-stdio'}`;
 }
 
 function toInfo(a: PendingAction): PendingActionInfo {
@@ -265,5 +446,6 @@ function toInfo(a: PendingAction): PendingActionInfo {
     summary: a.summary,
     createdAt: a.createdAt,
     expiresAt: a.expiresAt,
+    initiator: a.initiator,
   };
 }

--- a/src/core/rate-limiter.ts
+++ b/src/core/rate-limiter.ts
@@ -1,4 +1,7 @@
 import { logger } from '../logger.js';
+import { join } from 'node:path';
+import { withFileLock } from './file-lock.js';
+import { readJsonFile, safeStatePart, writeJsonAtomic } from './runtime-state.js';
 
 export interface RateSnapshot {
   domain: string;
@@ -16,19 +19,29 @@ export interface RateSnapshot {
 export class RateLimiter {
   private snapshots = new Map<string, RateSnapshot>();
 
-  observe(domain: string, headers: Headers): RateSnapshot {
+  constructor(
+    private readonly persistent?: { stateDir: string; namespace: string; lockTimeoutMs?: number },
+  ) {}
+
+  observe(domain: string, headers: Headers, displayDomain: string = domain): RateSnapshot {
     const limit = numberOrUndefined(headers.get('x-ratelimit-limit'));
     const remaining = numberOrUndefined(headers.get('x-ratelimit-remaining'));
     const resetRaw = headers.get('x-ratelimit-reset');
     const resetAt = resetRaw ? Number.parseInt(resetRaw, 10) : undefined;
     const snap: RateSnapshot = {
-      domain,
+      domain: displayDomain,
       limit,
       remaining,
       resetAt,
       observedAt: Math.floor(Date.now() / 1000),
     };
     this.snapshots.set(domain, snap);
+    const path = this.path(domain);
+    if (path) {
+      void withFileLock(path, () => writeJsonAtomic(path, snap), {
+        timeoutMs: this.persistent?.lockTimeoutMs ?? 30_000,
+      }).catch((error) => logger.warn({ error, domain }, 'failed to persist rate-limit snapshot'));
+    }
     if (remaining !== undefined && limit !== undefined && remaining <= 1) {
       logger.warn({ domain, remaining, limit }, 'rate-limit nearly exhausted');
     }
@@ -37,10 +50,43 @@ export class RateLimiter {
 
   /** If remaining <= 1, sleep softly for 1 second to let the reset window unfold. */
   async waitIfNeeded(domain: string): Promise<void> {
-    const snap = this.snapshots.get(domain);
-    if (!snap || snap.remaining === undefined) return;
-    if (snap.remaining <= 1) {
-      await sleep(1000);
+    const path = this.path(domain);
+    if (!path) {
+      const snap = this.snapshots.get(domain);
+      if (snap?.remaining !== undefined && snap.remaining <= 1) await sleep(1000);
+      return;
+    }
+    while (true) {
+      const delay = await withFileLock(
+        path,
+        async () => {
+          const snap = await readJsonFile<RateSnapshot>(path);
+          if (!snap || snap.remaining === undefined) return 0;
+          const now = Math.floor(Date.now() / 1000);
+          if (snap.resetAt === undefined && now > snap.observedAt) {
+            const stale = { ...snap, remaining: undefined, observedAt: now };
+            await writeJsonAtomic(path, stale);
+            this.snapshots.set(domain, stale);
+            return 0;
+          }
+          if (snap.resetAt !== undefined && snap.resetAt <= now) {
+            const refreshed = { ...snap, remaining: Math.max(0, (snap.limit ?? 1) - 1), observedAt: now };
+            await writeJsonAtomic(path, refreshed);
+            this.snapshots.set(domain, refreshed);
+            return 0;
+          }
+          if (snap.remaining > 1) {
+            const reserved = { ...snap, remaining: snap.remaining - 1 };
+            await writeJsonAtomic(path, reserved);
+            this.snapshots.set(domain, reserved);
+            return 0;
+          }
+          return snap.resetAt && snap.resetAt > now ? (snap.resetAt - now) * 1000 : 1000;
+        },
+        { timeoutMs: this.persistent?.lockTimeoutMs ?? 30_000 },
+      );
+      if (delay === 0) return;
+      await sleep(Math.min(delay, 30_000));
     }
   }
 
@@ -50,6 +96,36 @@ export class RateLimiter {
       return s ? [s] : [];
     }
     return [...this.snapshots.values()];
+  }
+
+  async getSharedStatus(domain?: string): Promise<RateSnapshot[]> {
+    if (!this.persistent) return this.getStatus(domain);
+    if (domain) {
+      const snapshot = await readJsonFile<RateSnapshot>(this.path(domain)!);
+      return snapshot ? [snapshot] : [];
+    }
+    const directory = join(this.persistent.stateDir, this.persistent.namespace, 'rate-limits');
+    let names: string[];
+    try {
+      names = await import('node:fs').then(({ promises }) => promises.readdir(directory));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+    const rows = await Promise.all(
+      names.filter((name) => name.endsWith('.json')).map((name) => readJsonFile<RateSnapshot>(join(directory, name))),
+    );
+    return rows.filter((row): row is RateSnapshot => row !== undefined);
+  }
+
+  private path(domain: string): string | undefined {
+    if (!this.persistent) return undefined;
+    return join(
+      this.persistent.stateDir,
+      this.persistent.namespace,
+      'rate-limits',
+      `${safeStatePart(domain)}.json`,
+    );
   }
 }
 

--- a/src/core/runtime-state.ts
+++ b/src/core/runtime-state.ts
@@ -1,0 +1,61 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import type { Config } from '../config.js';
+
+export function runtimeNamespace(config: Pick<Config, 'baseUrl' | 'clientId' | 'profileId'>): string {
+  return createHash('sha256')
+    .update('avito-mcp:runtime:v1\0')
+    .update(config.baseUrl)
+    .update('\0')
+    .update(config.clientId)
+    .update('\0')
+    .update(String(config.profileId ?? 'unconfigured'))
+    .digest('hex');
+}
+
+export function runtimeStateDirectory(config: Pick<Config, 'runtimeStateDir' | 'tokenFile'>): string {
+  return config.runtimeStateDir ?? join(dirname(config.tokenFile), 'runtime');
+}
+
+export function safeStatePart(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export async function readJsonFile<T>(path: string): Promise<T | undefined> {
+  try {
+    const stat = await fs.lstat(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`Unsafe runtime state file: ${path}`);
+    return JSON.parse(await fs.readFile(path, 'utf8')) as T;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
+export async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  const directory = dirname(path);
+  await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+  await fs.chmod(directory, 0o700);
+  const temp = join(directory, `.${randomBytes(12).toString('hex')}.tmp`);
+  const handle = await fs.open(temp, 'wx', 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(value)}\n`, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await fs.rename(temp, path);
+    const dir = await fs.open(directory, 'r');
+    try {
+      await dir.sync();
+    } finally {
+      await dir.close();
+    }
+  } catch (error) {
+    await fs.rm(temp, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}

--- a/src/core/tool-factory.ts
+++ b/src/core/tool-factory.ts
@@ -18,8 +18,9 @@ import {
   type IdempotencyStore,
   IdempotencyConflictError,
   IdempotencyLimitError,
+  IdempotencyRecoveryRequiredError,
 } from './idempotency.js';
-import type { PendingActionStore } from './pending-actions.js';
+import { callerPrincipal, type CallerExtra, type PendingActionStore } from './pending-actions.js';
 import { evaluatePolicy, requiresConfirmation } from './policy.js';
 import type { Primitive, QueryValue } from './url.js';
 import type { WebhookStore } from './webhook-store.js';
@@ -287,9 +288,30 @@ export function defineTool<I extends ZodRawShape>(
     }
   };
 
+  const executePending = async (
+    pendingArgs: Record<string, unknown>,
+    pendingIdempotencyKey?: string,
+    pendingArgsHash?: string,
+  ): Promise<CallToolResult> => {
+    const result = await execute(pendingArgs);
+    if (pendingIdempotencyKey && pendingArgsHash && ctx.idempotencyStore) {
+      await ctx.idempotencyStore.rememberPersistent(
+        pendingIdempotencyKey,
+        spec.name,
+        pendingArgsHash,
+        result,
+      );
+    }
+    return result;
+  };
+  if (isDestructive(risk)) ctx.pendingStore.registerExecutor(spec.name, executePending);
+
   const destructive = isDestructive(risk);
 
-  const handler = async (rawArgs: Record<string, unknown>): Promise<CallToolResult> => {
+  const handler = async (
+    rawArgs: Record<string, unknown>,
+    extra?: CallerExtra,
+  ): Promise<CallToolResult> => {
     const args = rawArgs ?? {};
     const cleanArgs = destructive ? stripMeta(args) : args;
 
@@ -354,18 +376,15 @@ export function defineTool<I extends ZodRawShape>(
 
     if (requiresConfirmation(risk, ctx.config)) {
       const createPending = async (): Promise<CallToolResult> => {
-        const pending = ctx.pendingStore.create({
+        const pending = await ctx.pendingStore.createPersistent({
           toolName: spec.name,
           risk,
           summary: summarisePending(spec, cleanArgs),
           args: cleanArgs,
-          execute: async () => {
-            const r = await execute(cleanArgs);
-            if (idempotencyKey && ctx.idempotencyStore && argsHash) {
-              ctx.idempotencyStore.remember(idempotencyKey, spec.name, argsHash, r);
-            }
-            return r;
-          },
+          initiator: callerPrincipal(extra),
+          idempotencyKey,
+          argsHash,
+          execute: () => executePending(cleanArgs, idempotencyKey, argsHash),
         });
         return {
           content: [
@@ -437,7 +456,11 @@ export function defineTool<I extends ZodRawShape>(
         );
         return replay ? annotateReplay(entry.result) : entry.result;
       } catch (err) {
-        if (err instanceof IdempotencyConflictError || err instanceof IdempotencyLimitError) {
+        if (
+          err instanceof IdempotencyConflictError ||
+          err instanceof IdempotencyLimitError ||
+          err instanceof IdempotencyRecoveryRequiredError
+        ) {
           return errorToMcpContent(err);
         }
         throw err;

--- a/src/domains/items.ts
+++ b/src/domains/items.ts
@@ -160,7 +160,7 @@ export const register: DomainRegister = (server, ctx) => {
         )
         .optional()
         .describe(
-          'Which metrics (counters) to return: uniqViews (unique views), uniqContacts (unique contacts), uniqFavorites (unique favorites added), calls. If unspecified, all available ones are returned.',
+          'Which metrics to return: views, uniqViews, contacts, uniqContacts, favorites, uniqFavorites. Calls are not supported here; use items_post_calls_stats. If omitted, all supported counters are returned.',
         ),
       user_id: z.number().int().positive().optional().describe('ID of the owner user. Defaults to Profile_id from .env.'),
     },
@@ -224,7 +224,7 @@ export const register: DomainRegister = (server, ctx) => {
     title: 'Profile spendings',
     risk: 'read',
     description:
-      'Returns a REPORT of the profile\'s spendings over a period by service type (post_account_spendings) — how much was spent on vas/cpa/tariff, etc. ' +
+      'Returns a REPORT of the profile\'s spendings over a period by Avito spending category: all, promotion, presence, commission, or rest. ' +
       'Read-only, spends no money (only shows already incurred spending). Period dateFrom..dateTo (YYYY-MM-DD). ' +
       'Note: grouping here is a STRING "day"|"week"|"month" (NOT an object, unlike items_post_item_analytics). Data depth no more than 270 days, no more than 1 request per minute. Required: dateFrom, dateTo, spendingTypes, grouping.',
     method: 'POST',
@@ -234,9 +234,9 @@ export const register: DomainRegister = (server, ctx) => {
       dateFrom: z.string().describe('Start of the period, inclusive (YYYY-MM-DD); no more than 270 days back.'),
       dateTo: z.string().describe('End of the period, inclusive (YYYY-MM-DD).'),
       spendingTypes: z
-        .array(z.string())
+        .array(z.enum(['all', 'promotion', 'presence', 'commission', 'rest']))
         .min(1)
-        .describe('Spending types for the report (at least 1): vas, perf_vas, lf, cv, tariff, subscription, cpa, bundle.'),
+        .describe('Spending categories from the Avito contract (at least 1): all, promotion, presence, commission, rest.'),
       grouping: z
         .enum(['day', 'week', 'month'])
         .describe('Group spendings by period — a string (required): day (by day), week (by week), month (by month).'),

--- a/src/domains/meta.ts
+++ b/src/domains/meta.ts
@@ -10,14 +10,16 @@
  * which optionally attempts a ping via a client_credentials refresh).
  */
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { createHash, timingSafeEqual } from 'node:crypto';
+import { timingSafeEqual } from 'node:crypto';
 import { z } from 'zod';
 
 import { logger } from '../logger.js';
 import { hasConfiguredCredentials } from '../core/credentials.js';
 import { evaluatePolicy, requiresConfirmation } from '../core/policy.js';
 import type { DomainRegister } from '../core/tool-factory.js';
-import { PACKAGE_NAME, VERSION } from '../version.js';
+import { PACKAGE_NAME, VERSION, readManifestMetadata } from '../version.js';
+import { callerPrincipal } from '../core/pending-actions.js';
+import { runtimeNamespace } from '../core/runtime-state.js';
 
 /**
  * Constant-time secret comparison. Equal-length buffers required by Node's
@@ -28,21 +30,6 @@ function secretsMatch(provided: string, expected: string): boolean {
   const b = Buffer.from(expected, 'utf8');
   if (a.length !== b.length) return false;
   return timingSafeEqual(a, b);
-}
-
-function confirmationPrincipal(extra: {
-  authInfo?: { clientId?: string };
-  sessionId?: string;
-  requestInfo?: { headers?: Record<string, string | string[] | undefined> };
-}): string {
-  if (extra.authInfo?.clientId) return `oauth:${extra.authInfo.clientId}`;
-  const raw = extra.requestInfo?.headers?.authorization;
-  const authorization = Array.isArray(raw) ? raw[0] : raw;
-  const bearer = /^Bearer\s+(.+)$/i.exec(authorization ?? '')?.[1];
-  if (bearer) {
-    return `bearer:${createHash('sha256').update(bearer).digest('base64url')}`;
-  }
-  return `session:${extra.sessionId ?? 'local-stdio'}`;
 }
 
 export const register: DomainRegister = (server, ctx) => {
@@ -61,7 +48,7 @@ export const register: DomainRegister = (server, ctx) => {
         title: 'Rate-limit status',
         description:
           'Returns the most recently observed X-RateLimit-Limit / X-RateLimit-Remaining / X-RateLimit-Reset values, ' +
-          'grouped by logical API domain (core, messenger, items, etc.). ' +
+          'grouped by logical API domain (core, messenger, items, etc.) across all processes in the current account namespace. ' +
           'Useful for diagnosing "why am I being throttled" — Avito enforces a per-minute limit.',
         inputSchema: {},
         annotations: {
@@ -73,7 +60,7 @@ export const register: DomainRegister = (server, ctx) => {
         _meta: { risk: 'read', environment: 'local' },
       },
       async (): Promise<CallToolResult> => {
-        const snaps = ctx.client.rateLimiter.getStatus();
+        const snaps = await ctx.client.rateLimiter.getSharedStatus();
         if (snaps.length === 0) {
           return {
             content: [{ type: 'text', text: 'No data: no requests to Avito have been made yet.' }],
@@ -273,6 +260,7 @@ export const register: DomainRegister = (server, ctx) => {
         outputSchema: {
           name: z.string(),
           version: z.string(),
+          schemaHash: z.string().nullable(),
           mode: z.string(),
           allowToolsCount: z.number().int(),
           denyToolsCount: z.number().int(),
@@ -283,17 +271,47 @@ export const register: DomainRegister = (server, ctx) => {
             hardConfirmation: z.boolean(),
             fileUploads: z.boolean(),
             sensitiveAuthTools: z.boolean(),
+            persistentState: z.boolean(),
+            sharedRateLimiter: z.boolean(),
+            reusableHttpBroker: z.boolean(),
           }),
           confirmationMode: z.string(),
+          approvalMode: z.string(),
           dryRunDefault: z.boolean(),
           idempotencyTtlSec: z.number().int(),
+          account: z.object({ profileId: z.string().nullable(), namespace: z.string() }),
+          tools: z.array(
+            z.object({
+              name: z.string(),
+              domain: z.string(),
+              risk: z.string(),
+              environment: z.string(),
+              available: z.boolean(),
+              requiredScopes: z.array(z.string()),
+            }),
+          ),
+          moneyUnits: z.object({ default: z.string(), bbip: z.string(), wallet: z.string() }),
         },
         _meta: { risk: 'read', environment: 'local' },
       },
       async (): Promise<CallToolResult> => {
+        const manifest = readManifestMetadata();
+        const tools = manifest.tools.map((value) => {
+          const tool = value as { name?: string; domain?: string; risk?: string; environment?: string };
+          const risk = (tool.risk ?? 'write') as 'read' | 'write' | 'money' | 'public' | 'sensitive';
+          return {
+            name: tool.name ?? 'unknown',
+            domain: tool.domain ?? 'unknown',
+            risk,
+            environment: tool.environment ?? 'prod',
+            available: evaluatePolicy(tool.name ?? 'unknown', risk, ctx.config).allowed,
+            requiredScopes: [],
+          };
+        });
         const payload = {
           name: PACKAGE_NAME,
           version: VERSION,
+          schemaHash: manifest.schemaHash,
           mode: ctx.config.mode,
           allowToolsCount: ctx.config.allowTools.length,
           denyToolsCount: ctx.config.denyTools.length,
@@ -304,10 +322,21 @@ export const register: DomainRegister = (server, ctx) => {
             hardConfirmation: !!ctx.config.confirmationSecret,
             fileUploads: ctx.config.allowedUploadDirs.length > 0,
             sensitiveAuthTools: ctx.config.exposeAuthTools,
+            persistentState: true,
+            sharedRateLimiter: true,
+            reusableHttpBroker:
+              ctx.config.http.transport === 'http' || ctx.config.http.transport === 'both',
           },
           confirmationMode: ctx.config.confirmationMode,
+          approvalMode: ctx.config.approvalMode ?? 'self',
           dryRunDefault: ctx.config.dryRunDefault,
           idempotencyTtlSec: ctx.config.idempotencyTtlSec,
+          account: {
+            profileId: ctx.config.profileId === undefined ? null : String(ctx.config.profileId),
+            namespace: runtimeNamespace(ctx.config).slice(0, 16),
+          },
+          tools,
+          moneyUnits: { default: 'documented-per-field', bbip: 'kopecks', wallet: 'rubles' },
         };
         return {
           content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
@@ -399,7 +428,7 @@ export const register: DomainRegister = (server, ctx) => {
         const id = String(args.confirmation_id ?? '');
 
         if (requireSecret) {
-          const rate = ctx.pendingStore.checkConfirmationRateLimit(confirmationPrincipal(extra));
+          const rate = ctx.pendingStore.checkConfirmationRateLimit(callerPrincipal(extra));
           if (!rate.allowed) {
             logger.warn(
               { retryAfterMs: rate.retryAfterMs },
@@ -420,7 +449,7 @@ export const register: DomainRegister = (server, ctx) => {
           }
         }
 
-        const pending = ctx.pendingStore.get(id);
+        const pending = await ctx.pendingStore.getPersistent(id);
         if (!pending) {
           return {
             isError: true,
@@ -478,10 +507,29 @@ export const register: DomainRegister = (server, ctx) => {
           }
           ctx.pendingStore.resetConfirmationFailures(id);
         }
+        const confirmer = requireSecret ? 'external:secret-provider' : callerPrincipal(extra);
+        if (ctx.config.approvalMode === 'external' && confirmer === pending.initiator) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: 'Confirmation rejected: external approval requires an identity different from the action initiator.',
+              },
+            ],
+            structuredContent: {
+              error: {
+                code: 'APPROVER_MUST_DIFFER',
+                message: 'The initiator cannot approve this action in external approval mode.',
+                retryable: false,
+              },
+            },
+          };
+        }
         // Re-evaluate policy — the user may have changed the config between create and confirm.
         const decision = evaluatePolicy(pending.toolName, pending.risk, ctx.config);
         if (!decision.allowed) {
-          ctx.pendingStore.delete(id);
+          await ctx.pendingStore.deletePersistent(id);
           return {
             isError: true,
             content: [
@@ -494,7 +542,7 @@ export const register: DomainRegister = (server, ctx) => {
         }
         // Atomically claim before execution. A concurrent session that passed
         // the checks above must not execute the same pending mutation twice.
-        const claimed = ctx.pendingStore.take(id);
+        const claimed = await ctx.pendingStore.takePersistent(id);
         if (!claimed) {
           return {
             isError: true,
@@ -555,7 +603,7 @@ export const register: DomainRegister = (server, ctx) => {
       },
       async (args): Promise<CallToolResult> => {
         const id = String(args.confirmation_id ?? '');
-        const existed = ctx.pendingStore.delete(id);
+        const existed = await ctx.pendingStore.deletePersistent(id);
         return {
           content: [
             {
@@ -598,7 +646,7 @@ export const register: DomainRegister = (server, ctx) => {
         _meta: { risk: 'read', environment: 'local' },
       },
       async (): Promise<CallToolResult> => {
-        const items = ctx.pendingStore.list();
+        const items = await ctx.pendingStore.listPersistent();
         if (items.length === 0) {
           return {
             content: [{ type: 'text', text: 'No pending actions.' }],

--- a/src/domains/promotion.ts
+++ b/src/domains/promotion.ts
@@ -8,6 +8,51 @@ import { z } from 'zod';
 
 import { defineTool, type DomainRegister } from '../core/tool-factory.js';
 
+interface BbipItemStatus {
+  itemId?: number | string;
+  status?: string;
+  price?: number;
+  errorReason?: string | null;
+  [key: string]: unknown;
+}
+
+export function normalizeBbipResult(
+  data: unknown,
+  requestedItemIds?: Array<number | string>,
+): Record<string, unknown> {
+  const source = data && typeof data === 'object' ? (data as Record<string, unknown>) : {};
+  const items = Array.isArray(source.items) ? (source.items as BbipItemStatus[]) : [];
+  const successful = items.filter((item) => item.status === 'processed' || item.status === 'active');
+  const failed = items.filter((item) => item.status === 'error' || item.status === 'canceled');
+  const pending = items.filter((item) => ['initialized', 'waiting', 'in_process'].includes(item.status ?? ''));
+  const normalizedItems = items.map((item) => ({
+    ...item,
+    error_code:
+      item.status === 'error' && /конфликт|conflict/i.test(item.errorReason ?? '')
+        ? 'PROMOTION_CONFLICT'
+        : item.status === 'error'
+          ? 'PROMOTION_ITEM_FAILED'
+          : null,
+  }));
+  let outcome: 'success' | 'partial' | 'failed' | 'pending' | 'unknown' = 'unknown';
+  if (pending.length > 0 || ['initialized', 'waiting', 'in_process'].includes(String(source.status ?? ''))) outcome = 'pending';
+  else if (failed.length > 0 && successful.length > 0) outcome = 'partial';
+  else if (failed.length > 0) outcome = 'failed';
+  else if (items.length > 0 && successful.length === items.length) outcome = 'success';
+  return {
+    ...source,
+    items: normalizedItems,
+    outcome,
+    requested_item_ids: requestedItemIds ?? null,
+    accepted_item_ids: successful.map((item) => item.itemId),
+    failed_item_ids: failed.map((item) => item.itemId),
+    confirmed_cost_kopecks:
+      typeof source.totalPrice === 'number'
+        ? source.totalPrice
+        : successful.reduce((sum, item) => sum + (typeof item.price === 'number' ? item.price : 0), 0),
+  };
+}
+
 // Actual Avito BBIP contract: both forecasts (BbipForecastRequestByItemV1) and create
 // (BbipOrderByItemV1) require the SAME set of itemId+duration+oldPrice+price.
 // Values come from promotion_get_bbip_suggests_by_items_v1: budgets[].{oldPrice,price}
@@ -120,6 +165,35 @@ export const register: DomainRegister = (server, ctx) => {
         ),
     },
     body: { contentType: 'application/json', fields: ['items'] },
+    customExecute: async (args, toolCtx) => {
+      const created = await toolCtx.client.request<Record<string, unknown>>({
+        method: 'PUT',
+        path: '/promotion/v1/items/services/bbip/orders/create',
+        domain: 'promotion',
+        body: { items: args.items },
+      });
+      const orderId = typeof created.data.orderId === 'string' ? created.data.orderId : undefined;
+      const requested = Array.isArray(args.items)
+        ? args.items
+            .map((item) => (item as { itemId?: number | string }).itemId)
+            .filter((id): id is number | string => id !== undefined)
+        : [];
+      if (!orderId) return { ...created, data: normalizeBbipResult(created.data, requested) };
+      let last: Record<string, unknown> = created.data;
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        const status = await toolCtx.client.request<Record<string, unknown>>({
+          method: 'POST',
+          path: '/promotion/v1/items/services/orders/status',
+          domain: 'promotion',
+          body: { orderId },
+        });
+        last = status.data;
+        const normalized = normalizeBbipResult(last, requested);
+        if (normalized.outcome !== 'pending') return { ...status, data: normalized };
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+      return { ...created, data: normalizeBbipResult(last, requested) };
+    },
   });
 
   defineTool(server, ctx, {
@@ -205,5 +279,14 @@ export const register: DomainRegister = (server, ctx) => {
         .describe('Promotion order identifier in UUID format, obtained from promotion_create_bbip_order_for_items_v1.'),
     },
     body: { contentType: 'application/json', fields: ['orderId'] },
+    customExecute: async (args, toolCtx) => {
+      const response = await toolCtx.client.request<Record<string, unknown>>({
+        method: 'POST',
+        path: '/promotion/v1/items/services/orders/status',
+        domain: 'promotion',
+        body: { orderId: args.orderId },
+      });
+      return { ...response, data: normalizeBbipResult(response.data) };
+    },
   });
 };

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -61,7 +61,7 @@ export function registerPrompts(server: McpServer, ctx: ToolContext): void {
               `  3. items_post_account_spendings {\n` +
               `       dateFrom: "${dateFrom}",\n` +
               `       dateTo:   "${dateTo}",\n` +
-              `       spendingTypes: ["vas","perf_vas","tariff","cpa"],\n` +
+              `       spendingTypes: ["all"],\n` +
               `       grouping: "day"\n` +
               `     }\n\n` +
               `Produce a summary: balance, number of active listings (by status), ` +
@@ -74,7 +74,7 @@ export function registerPrompts(server: McpServer, ctx: ToolContext): void {
               `  3. items_post_account_spendings {\n` +
               `       dateFrom: "${dateFrom}",\n` +
               `       dateTo:   "${dateTo}",\n` +
-              `       spendingTypes: ["vas","perf_vas","tariff","cpa"],\n` +
+              `       spendingTypes: ["all"],\n` +
               `       grouping: "day"\n` +
               `     }\n\n` +
               `Сформируй итог: баланс, количество активных объявлений (по статусам), ` +

--- a/src/server.ts
+++ b/src/server.ts
@@ -119,6 +119,7 @@ async function startServer(): Promise<void> {
     { PendingActionStore },
     { IdempotencyStore },
     { WebhookStore },
+    { runtimeNamespace, runtimeStateDirectory },
     { buildMcpServer },
   ] = await Promise.all([
     import('./config.js'),
@@ -128,14 +129,24 @@ async function startServer(): Promise<void> {
     import('./core/pending-actions.js'),
     import('./core/idempotency.js'),
     import('./core/webhook-store.js'),
+    import('./core/runtime-state.js'),
     import('./build-server.js'),
   ]);
 
   // Shared singletons. They back the stdio server AND every Streamable HTTP session,
   // so the Avito client and token cache are never duplicated across sessions.
   const client = new AvitoClient(config);
-  const pendingStore = new PendingActionStore(config.confirmationTtlSec * 1000);
-  const idempotencyStore = new IdempotencyStore(config.idempotencyTtlSec * 1000);
+  const namespace = runtimeNamespace(config);
+  const pendingStore = new PendingActionStore(config.confirmationTtlSec * 1000, 1000, {
+    stateDir: runtimeStateDirectory(config),
+    namespace,
+    lockTimeoutMs: config.tokenLockTimeoutMs,
+  });
+  const idempotencyStore = new IdempotencyStore(config.idempotencyTtlSec * 1000, 10_000, {
+    stateDir: runtimeStateDirectory(config),
+    namespace,
+    lockTimeoutMs: config.tokenLockTimeoutMs,
+  });
   const webhookStore = config.webhook.enabled
     ? new WebhookStore(config.webhook.bufferSize, config.webhook.logFile)
     : undefined;

--- a/src/version.ts
+++ b/src/version.ts
@@ -12,3 +12,22 @@ const pkg = JSON.parse(pkgRaw) as { name: string; version: string };
 export const PACKAGE_NAME: string = pkg.name;
 export const VERSION: string = pkg.version;
 export const USER_AGENT = `${PACKAGE_NAME}/${VERSION}`;
+
+export function readManifestMetadata(): { schemaHash: string | null; tools: unknown[] } {
+  const candidates = [
+    join(here, 'manifest.json'),
+    join(here, '..', 'dist', 'manifest.json'),
+  ];
+  for (const path of candidates) {
+    try {
+      const manifest = JSON.parse(readFileSync(path, 'utf8')) as {
+        schema_hash?: string;
+        tools?: unknown[];
+      };
+      return { schemaHash: manifest.schema_hash ?? null, tools: manifest.tools ?? [] };
+    } catch {
+      // Development before generate:manifest; try the next canonical location.
+    }
+  }
+  return { schemaHash: null, tools: [] };
+}

--- a/test/manifest-snapshot.test.ts
+++ b/test/manifest-snapshot.test.ts
@@ -47,7 +47,7 @@ beforeAll(() => {
 
 describe('manifest snapshot', () => {
   it('uses the deterministic manifest schema version', () => {
-    expect(manifest.schema_version).toBe(1);
+    expect(manifest.schema_version).toBe(2);
     expect(manifest).not.toHaveProperty('$schema');
     expect(manifest).not.toHaveProperty('generated_at');
   });

--- a/test/reliability-1.3.test.ts
+++ b/test/reliability-1.3.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { IdempotencyStore } from '../src/core/idempotency.js';
+import { PendingActionStore } from '../src/core/pending-actions.js';
+import { RateLimiter } from '../src/core/rate-limiter.js';
+import { normalizeBbipResult } from '../src/domains/promotion.js';
+
+const directories: string[] = [];
+
+async function stateDir(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'avito-mcp-1.3-'));
+  directories.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe('BBIP item-level outcome', () => {
+  it('does not report success when a processed order contains an item error', () => {
+    const result = normalizeBbipResult({
+      orderId: 'order-1',
+      status: 'processed',
+      totalPrice: 5000,
+      items: [
+        { itemId: '1', status: 'processed', price: 5000 },
+        { itemId: '2', status: 'error', errorReason: 'Есть конфликтующая услуга' },
+      ],
+    });
+
+    expect(result.outcome).toBe('partial');
+    expect(result.accepted_item_ids).toEqual(['1']);
+    expect(result.failed_item_ids).toEqual(['2']);
+    expect(result.items).toMatchObject([
+      { error_code: null },
+      { error_code: 'PROMOTION_CONFLICT' },
+    ]);
+  });
+});
+
+describe('1.3 durable reliability state', () => {
+  it('replays a completed destructive result in a second process store', async () => {
+    const directory = await stateDir();
+    const options = { stateDir: directory, namespace: 'account-a' };
+    const first = new IdempotencyStore(60_000, 100, options);
+    const second = new IdempotencyStore(60_000, 100, options);
+    let executions = 0;
+
+    const initial = await first.runExclusive('business-key', 'money_tool', 'same-args', async () => {
+      executions += 1;
+      return { content: [{ type: 'text', text: 'charged once' }] };
+    });
+    const replay = await second.runExclusive('business-key', 'money_tool', 'same-args', async () => {
+      executions += 1;
+      return { content: [{ type: 'text', text: 'must not run' }] };
+    });
+
+    expect(initial.replay).toBe(false);
+    expect(replay.replay).toBe(true);
+    expect(replay.entry.result.content[0]).toMatchObject({ text: 'charged once' });
+    expect(executions).toBe(1);
+  });
+
+  it('rehydrates and atomically claims a pending action in another store', async () => {
+    const directory = await stateDir();
+    const options = { stateDir: directory, namespace: 'account-a' };
+    const first = new PendingActionStore(60_000, 100, options);
+    const second = new PendingActionStore(60_000, 100, options);
+    second.registerExecutor('money_tool', async (args) => ({
+      content: [{ type: 'text', text: `executed:${String(args.itemId)}` }],
+    }));
+
+    const created = await first.createPersistent({
+      toolName: 'money_tool',
+      risk: 'money',
+      summary: 'test',
+      args: { itemId: '8028191653' },
+      initiator: 'oauth:initiator',
+      execute: async () => ({ content: [{ type: 'text', text: 'local' }] }),
+    });
+    const recovered = await second.getPersistent(created.id);
+    const claimed = await second.takePersistent(created.id);
+
+    expect(recovered?.initiator).toBe('oauth:initiator');
+    expect(await claimed?.execute()).toMatchObject({
+      content: [{ type: 'text', text: 'executed:8028191653' }],
+    });
+    expect(await first.takePersistent(created.id)).toBeUndefined();
+  });
+
+  it('shares observed rate-limit state by account namespace', async () => {
+    const directory = await stateDir();
+    const options = { stateDir: directory, namespace: 'account-a' };
+    const first = new RateLimiter(options);
+    const second = new RateLimiter(options);
+    const headers = new Headers({
+      'x-ratelimit-limit': '10',
+      'x-ratelimit-remaining': '7',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 60),
+    });
+    first.observe('stats', headers);
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const shared = await second.getSharedStatus('stats');
+      if (shared.length > 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(await second.getSharedStatus('stats')).toMatchObject([
+      { domain: 'stats', limit: 10, remaining: 7 },
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

- add durable account-scoped idempotency reservations and pending approvals shared across stdio processes
- share endpoint rate-limit observations/reservations and expose the common view through `meta_get_rate_limits`
- add external approval mode, expanded `meta_capabilities`, manifest schema hashes, and structured error aliases
- correct the spendings enum and shallow-stats guidance
- poll and normalize BBIP order results at item level, including partial failures and promotion conflicts
- bump all release metadata and documentation to 1.3.0

## Why

Version 1.2.0 kept destructive coordination in process memory, so restarts and parallel stdio backends could lose idempotency/pending state or independently exceed a shared Avito quota. BBIP also allowed an order-level `processed` status to obscure item-level failures. This release moves coordination into an account-isolated durable runtime layer and makes the paid-operation result machine-verifiable.

## Impact

All 148 existing tool names remain compatible. Runtime state is enabled by default below the token state directory and can be moved with `AVITO_MCP_RUNTIME_STATE_DIR`. Existing approval behavior remains `self`; operators can opt into `AVITO_MCP_APPROVAL_MODE=external` with a strong confirmation secret.

Portfolio cursors, business snapshots, ID bridges, economics adapters, and a dedicated Unix-socket shim remain scoped to 1.4.x.

## Validation

- `npm run verify:release`
- 335/335 tests across 31 files
- coverage: 80.89% statements, 71.74% branches, 81.83% functions, 83.81% lines
- `npm audit --audit-level=high` — 0 vulnerabilities
- manifest: 148 tools, no unknown risk classes
