### PR TITLE
Release 1.3.1: harden runtime state readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
           AVITO_MCP_HTTP_AUTH=oauth
           AVITO_MCP_OAUTH_OWNER_PASSWORD=ci-only-owner-password-at-least-32-bytes
           AVITO_MCP_OAUTH_STORE_FILE=/var/lib/avito-mcp/oauth-state.json
+          AVITO_MCP_RUNTIME_STATE_DIR=/var/lib/avito-mcp/runtime-state
           AVITO_MCP_WEBHOOK_ENABLED=true
           AVITO_MCP_WEBHOOK_SECRET=ci-webhook-secret-at-least-32-bytes
           AVITO_MCP_WEBHOOK_PUBLIC_URL=https://mcp.example.com
@@ -243,6 +244,10 @@ jobs:
           test "$(sudo stat -c %a /var/lib/avito-mcp/webhook-events.jsonl)" = 600
           sudo -u avito-mcp test -r /var/lib/avito-mcp/webhook-events.jsonl
           sudo -u avito-mcp test -w /var/lib/avito-mcp/webhook-events.jsonl
+          test "$(sudo stat -c %U:%G /var/lib/avito-mcp/runtime-state)" = avito-mcp:avito-mcp
+          sudo -u avito-mcp test -r /var/lib/avito-mcp/runtime-state
+          sudo -u avito-mcp test -w /var/lib/avito-mcp/runtime-state
+          sudo -u avito-mcp test -x /var/lib/avito-mcp/runtime-state
           test "$(sudo sha256sum /var/lib/avito-mcp/webhook-events.jsonl | cut -d ' ' -f 1)" = "$legacy_state_hash"
           test "$(systemctl show avito-mcp.service --property=User --value)" = avito-mcp
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-07-14
+
+Patch release for runtime-state placement and deployment readiness. The release gate passes **338 tests across 31 files** with **80.95% statements / 71.91% branches / 81.86% functions / 83.83% lines** coverage.
+
+### Fixed
+
+- The default durable runtime-state directory is now derived from the effective `AVITO_TOKEN_FILE`, so a custom token location keeps idempotency, pending approvals, and shared rate-limit state beside that token unless `AVITO_MCP_RUNTIME_STATE_DIR` is set explicitly.
+- `/readyz` now fails closed when the runtime-state directory cannot be created or accessed for reading, writing, and traversal.
+- The systemd installer validates `AVITO_MCP_RUNTIME_STATE_DIR`, creates it with private service ownership, and verifies access as the `avito-mcp` user before switching releases.
+- `--help` now documents `AVITO_MCP_APPROVAL_MODE` and `AVITO_MCP_RUNTIME_STATE_DIR`.
+
 ## [1.3.0] - 2026-07-14
 
 **Reliability release for autonomous Avito agents.** The destructive-operation pipeline now has durable, account-scoped coordination across stdio processes; the generated contract surface exposes a reproducible schema hash; and BBIP purchases return a verified item-level outcome instead of trusting the order-level HTTP/status alone. Existing 1.x tool names remain unchanged (148 tools). The release gate passes **335 tests across 31 files** with **80.89% statements / 71.74% branches / 81.83% functions / 83.81% lines** coverage.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <a href="https://glama.ai/mcp/servers/elchin92/avito-mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/elchin92/avito-mcp/badges/card.svg" alt="avito-mcp MCP server" /></a>
 
-> **New in v1.3.0** — durable account-scoped idempotency and pending approvals shared by stdio processes, a shared endpoint limiter, external approval mode, BBIP item-level terminal outcomes, generated schema hashes, and corrected spendings/shallow-stat contracts. See the [CHANGELOG](./CHANGELOG.md) for migration notes.
+> **New in v1.3.1** — runtime state now follows a custom `AVITO_TOKEN_FILE`; `/readyz` and the systemd installer verify that shared durable state is accessible. See the [CHANGELOG](./CHANGELOG.md) for details.
 
 ---
 
@@ -346,7 +346,7 @@ avito-mcp --health               # print JSON health snapshot and exit
 
 `--health` does not start the server; it is a local configuration/capability diagnostic, not a liveness probe for an already running process. The bundled Docker image checks PID 1 in stdio mode and the live `/readyz` endpoint in HTTP/webhook mode. For Kubernetes or a supervisor, probe:
 
-`/readyz` returns 200 only while the listener is open, HTTP-mode Avito credentials are complete, the token state directory is writable, the OAuth store lease is healthy, and configured webhook persistence has not failed. Its public body remains only `{ "ok": boolean }`.
+`/readyz` returns 200 only while the listener is open, HTTP-mode Avito credentials are complete, the token and runtime-state directories are writable, the OAuth store lease is healthy, and configured webhook persistence has not failed. Its public body remains only `{ "ok": boolean }`.
 
 ```yaml
 httpGet:

--- a/README.ru.md
+++ b/README.ru.md
@@ -19,7 +19,7 @@
 
 <a href="https://glama.ai/mcp/servers/elchin92/avito-mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/elchin92/avito-mcp/badges/card.svg" alt="avito-mcp MCP server" /></a>
 
-> **Новое в v1.3.0** — persistent account-scoped idempotency и pending approvals для нескольких stdio-процессов, общий endpoint limiter, external approval, item-level terminal outcome BBIP, schema hash и исправленные contracts spendings/shallow stats. Миграционные детали — в [CHANGELOG](./CHANGELOG.md).
+> **Новое в v1.3.1** — runtime state теперь следует за пользовательским `AVITO_TOKEN_FILE`; `/readyz` и systemd installer проверяют доступность общего durable state. Подробности — в [CHANGELOG](./CHANGELOG.md).
 
 ---
 
@@ -346,7 +346,7 @@ avito-mcp --health               # print JSON health snapshot and exit
 
 `--health` не запускает сервер: это локальная диагностика config/capabilities, а не liveness уже работающего процесса. Встроенный Docker HEALTHCHECK проверяет PID 1 в stdio и живой `/readyz` в HTTP/webhook режиме. Для Kubernetes/supervisor используйте:
 
-`/readyz` возвращает 200, только пока listener открыт, HTTP credentials Avito заполнены полностью, token state directory доступен для записи, lease OAuth store исправен и настроенная webhook persistence не завершалась ошибкой. Публичное тело остается только `{ "ok": boolean }`.
+`/readyz` возвращает 200, только пока listener открыт, HTTP credentials Avito заполнены полностью, token и runtime-state directories доступны для записи, lease OAuth store исправен и настроенная webhook persistence не завершалась ошибкой. Публичное тело остается только `{ "ok": boolean }`.
 
 ```yaml
 httpGet:

--- a/deploy/install-services.sh
+++ b/deploy/install-services.sh
@@ -15,6 +15,7 @@ HEALTH_BASE_URL=${AVITO_MCP_DEPLOY_HEALTH_URL:-}
 START_SERVICES=0
 STAGING_DIR=
 READY_FILE=
+RUNTIME_STATE_FILE=
 BACKUP_DIR=
 STATE_CREATED=0
 STATE_FROZEN=0
@@ -78,6 +79,9 @@ cleanup() {
   fi
   if [[ -n "$READY_FILE" ]]; then
     rm -f -- "$READY_FILE"
+  fi
+  if [[ -n "$RUNTIME_STATE_FILE" ]]; then
+    rm -f -- "$RUNTIME_STATE_FILE"
   fi
   if [[ -n "$BACKUP_DIR" && -d "$BACKUP_DIR" ]]; then
     rm -rf -- "$BACKUP_DIR"
@@ -357,8 +361,15 @@ fi
 TRANSACTION_ACTIVE=1
 install -d -o root -g root -m 0700 "$CONFIG_DIR"
 filtered_env=$BACKUP_DIR/new-avito-mcp.env
+RUNTIME_STATE_FILE=$BACKUP_DIR/runtime-state-dir
 rendered_health_url=$(node "$SOURCE_ROOT/deploy/render-service-env.mjs" \
-  "$release_dir/package.json" "$SOURCE_ROOT/.env" "$SOURCE_ROOT/.remote.env" "$filtered_env")
+  "$release_dir/package.json" "$SOURCE_ROOT/.env" "$SOURCE_ROOT/.remote.env" "$filtered_env" \
+  "$RUNTIME_STATE_FILE")
+runtime_state_dir=$(tr -d '\n' <"$RUNTIME_STATE_FILE")
+if [[ -z "$runtime_state_dir" ]]; then
+  printf 'Unable to resolve AVITO_MCP_RUNTIME_STATE_DIR\n' >&2
+  false
+fi
 if [[ -z "$HEALTH_BASE_URL" ]]; then HEALTH_BASE_URL=$rendered_health_url; fi
 install -o root -g root -m 0600 "$filtered_env" "$SERVICE_ENV"
 install -o root -g root -m 0644 \
@@ -392,6 +403,14 @@ if [[ $app_was_active -eq 1 ]]; then
   systemctl stop avito-mcp.service
 fi
 migrate_private_state avito-mcp "$STATE_DIR"
+install -d -o avito-mcp -g avito-mcp -m 0700 "$runtime_state_dir"
+if ! runuser -u avito-mcp -- test -r "$runtime_state_dir" || \
+  ! runuser -u avito-mcp -- test -w "$runtime_state_dir" || \
+  ! runuser -u avito-mcp -- test -x "$runtime_state_dir"; then
+  printf 'AVITO_MCP_RUNTIME_STATE_DIR is not accessible to avito-mcp: %s\n' \
+    "$runtime_state_dir" >&2
+  false
+fi
 systemctl daemon-reload
 
 # Switch only after config, units, and release layout pass static validation.

--- a/deploy/render-service-env.mjs
+++ b/deploy/render-service-env.mjs
@@ -2,9 +2,9 @@
 import { createRequire } from 'node:module';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { isIP } from 'node:net';
-import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
-const [packageJson, baseEnv, remoteEnv, outputFile] = process.argv.slice(2);
+const [packageJson, baseEnv, remoteEnv, outputFile, runtimeStateOutput] = process.argv.slice(2);
 if (!packageJson || !baseEnv || !remoteEnv || !outputFile) {
   process.stderr.write(
     'Usage: render-service-env.mjs <release-package.json> <base.env> <remote.env> <output>\n',
@@ -64,6 +64,30 @@ for (const key of [
   }
 }
 
+// The systemd unit grants write access only below StateDirectory=avito-mcp.
+// Resolve the same runtime-state default as config.ts so the installer can
+// create it and verify access as the service user before switching releases.
+const effectiveTokenFile =
+  typeof merged.AVITO_TOKEN_FILE === 'string' && merged.AVITO_TOKEN_FILE.trim() !== ''
+    ? resolve(merged.AVITO_TOKEN_FILE)
+    : join(serviceStateDirectory, 'avito-mcp', 'token.json');
+const runtimeStateDirectory =
+  typeof merged.AVITO_MCP_RUNTIME_STATE_DIR === 'string' &&
+  merged.AVITO_MCP_RUNTIME_STATE_DIR.trim() !== ''
+    ? resolve(merged.AVITO_MCP_RUNTIME_STATE_DIR)
+    : join(dirname(effectiveTokenFile), 'runtime');
+const runtimeRel = relative(serviceStateDirectory, runtimeStateDirectory);
+if (
+  (merged.AVITO_MCP_RUNTIME_STATE_DIR && !isAbsolute(merged.AVITO_MCP_RUNTIME_STATE_DIR)) ||
+  runtimeRel === '..' ||
+  runtimeRel.startsWith(`..${sep}`) ||
+  isAbsolute(runtimeRel)
+) {
+  throw new Error(
+    `AVITO_MCP_RUNTIME_STATE_DIR must be an absolute directory at or inside ${serviceStateDirectory}`,
+  );
+}
+
 const exactKeys = new Set([
   'Client_id',
   'Client_secret',
@@ -103,5 +127,12 @@ const lines = Object.entries(merged)
   .sort(([left], [right]) => left.localeCompare(right))
   .map(([key, value]) => `${key}=${quote(value, key)}`);
 writeFileSync(outputFile, `${lines.join('\n')}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+if (runtimeStateOutput) {
+  writeFileSync(runtimeStateOutput, `${runtimeStateDirectory}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+    mode: 0o600,
+  });
+}
 
 process.stdout.write(`http://${urlHost}:${portValue}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "avito-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "avito-mcp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avito-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "mcpName": "io.github.elchin92/avito-mcp",
   "description": "Universal MCP server for the Avito API — 148 tools across 18 domains, safe-by-default with dry-run, durable idempotency, external approval, shared rate limits and structured errors. Runs over stdio or a reusable OAuth 2.1-secured HTTP backend, with a built-in Avito webhook receiver.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/elchin92/avito-mcp",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "avito-mcp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -396,13 +396,14 @@ export type Config = Omit<ParsedConfig, 'approvalMode' | 'runtimeStateDir'> & {
 };
 
 function loadUnchecked(): Config {
+  const tokenFile = process.env.AVITO_TOKEN_FILE?.trim() || defaultTokenFile();
   const raw = {
     clientId: process.env.Client_id ?? process.env.CLIENT_ID,
     clientSecret: process.env.Client_secret ?? process.env.CLIENT_SECRET,
     profileId: process.env.Profile_id ?? process.env.PROFILE_ID,
     baseUrl: process.env.AVITO_BASE_URL,
     cpaSource: process.env.AVITO_MCP_CPA_SOURCE,
-    tokenFile: process.env.AVITO_TOKEN_FILE,
+    tokenFile,
     logLevel: process.env.LOG_LEVEL,
     mode: resolveMode(),
     allowTools: parseToolList(process.env.AVITO_MCP_ALLOW_TOOLS),
@@ -453,7 +454,7 @@ function loadUnchecked(): Config {
       604_800,
     ),
     runtimeStateDir:
-      process.env.AVITO_MCP_RUNTIME_STATE_DIR?.trim() || join(dirname(defaultTokenFile()), 'runtime'),
+      process.env.AVITO_MCP_RUNTIME_STATE_DIR?.trim() || join(dirname(tokenFile), 'runtime'),
     tokenLockTimeoutMs: parsePositiveInt(
       process.env.AVITO_MCP_TOKEN_LOCK_TIMEOUT_MS,
       30_000,

--- a/src/core/runtime-state.ts
+++ b/src/core/runtime-state.ts
@@ -1,10 +1,13 @@
 import { createHash, randomBytes } from 'node:crypto';
+import { constants } from 'node:fs';
 import { promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import type { Config } from '../config.js';
 
-export function runtimeNamespace(config: Pick<Config, 'baseUrl' | 'clientId' | 'profileId'>): string {
+export function runtimeNamespace(
+  config: Pick<Config, 'baseUrl' | 'clientId' | 'profileId'>,
+): string {
   return createHash('sha256')
     .update('avito-mcp:runtime:v1\0')
     .update(config.baseUrl)
@@ -15,8 +18,23 @@ export function runtimeNamespace(config: Pick<Config, 'baseUrl' | 'clientId' | '
     .digest('hex');
 }
 
-export function runtimeStateDirectory(config: Pick<Config, 'runtimeStateDir' | 'tokenFile'>): string {
+export function runtimeStateDirectory(
+  config: Pick<Config, 'runtimeStateDir' | 'tokenFile'>,
+): string {
   return config.runtimeStateDir ?? join(dirname(config.tokenFile), 'runtime');
+}
+
+/** Minimal readiness check for the shared idempotency/pending/limiter directory. */
+export async function isRuntimeStateReady(directory: string): Promise<boolean> {
+  try {
+    await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+    const stat = await fs.lstat(directory);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    await fs.access(directory, constants.R_OK | constants.W_OK | constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function safeStatePart(value: string): string {
@@ -26,7 +44,8 @@ export function safeStatePart(value: string): string {
 export async function readJsonFile<T>(path: string): Promise<T | undefined> {
   try {
     const stat = await fs.lstat(path);
-    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`Unsafe runtime state file: ${path}`);
+    if (!stat.isFile() || stat.isSymbolicLink())
+      throw new Error(`Unsafe runtime state file: ${path}`);
     return JSON.parse(await fs.readFile(path, 'utf8')) as T;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -20,6 +20,7 @@ import type { Server as HttpServer } from 'node:http';
 import type { Config, HttpConfig } from '../config.js';
 import type { ToolContext } from '../core/tool-factory.js';
 import { hasConfiguredCredentials } from '../core/credentials.js';
+import { isRuntimeStateReady, runtimeStateDirectory } from '../core/runtime-state.js';
 import { logger } from '../logger.js';
 import { PACKAGE_NAME, VERSION } from '../version.js';
 import { createOAuthSubsystem } from './oauth/index.js';
@@ -133,8 +134,9 @@ export async function startHttpServer(
     const apiReady =
       !httpMcpEnabled ||
       (hasConfiguredCredentials(config) && (await baseCtx.client.tokenStore.isStorageReady()));
+    const runtimeReady = await isRuntimeStateReady(runtimeStateDirectory(config));
     const webhookReady = baseCtx.webhookStore?.isReady() ?? true;
-    const ready = !closing && apiReady && webhookReady && (oauthReady?.() ?? true);
+    const ready = !closing && apiReady && runtimeReady && webhookReady && (oauthReady?.() ?? true);
     res.status(ready ? 200 : 503).json({ ok: ready });
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ function printHelp(): void {
       `  AVITO_MCP_ALLOW_TOOLS   Comma-separated tool names; if set, only these register\n` +
       `  AVITO_MCP_DENY_TOOLS    Comma-separated tool names; always blocked (wins over allow)\n` +
       `  AVITO_MCP_CONFIRMATION_MODE     off | money_public (default) | all_destructive\n` +
+      `  AVITO_MCP_APPROVAL_MODE         self (default) | external\n` +
       `  AVITO_MCP_CONFIRMATION_TTL_SEC  Pending action TTL in seconds (default: 900)\n` +
       `  AVITO_MCP_CONFIRMATION_SECRET   Enables hard-confirmation (minimum 32 characters)\n` +
       `  AVITO_MCP_EXPOSE_AUTH_TOOLS     1 to expose sensitive auth_* tools (default: hidden)\n` +
@@ -44,6 +45,7 @@ function printHelp(): void {
       `  AVITO_MCP_DRY_RUN_DEFAULT       v0.7.0: default for dryRun on destructive tools\n` +
       `                                  (true|false; default: false)\n` +
       `  AVITO_MCP_IDEMPOTENCY_TTL_SEC   v0.7.0: TTL of idempotency ledger entries (default: 3600)\n` +
+      `  AVITO_MCP_RUNTIME_STATE_DIR      Shared durable state directory (default: beside AVITO_TOKEN_FILE)\n` +
       `  AVITO_MCP_TOKEN_LOCK_TIMEOUT_MS v0.7.0: max wait for cross-process token lock (default: 30000)\n` +
       `  AVITO_SAFE_MODE         DEPRECATED: use AVITO_MCP_MODE=read_only instead\n` +
       `  LOG_LEVEL               pino log level (default: info)\n` +
@@ -155,7 +157,8 @@ async function startServer(): Promise<void> {
   // v0.7.4: credentials are optional at startup. If absent, we still register the full
   // catalogue (tools/list works) but warn loudly — any API call will fail with CONFIG_ERROR
   // until Client_id/Client_secret/Profile_id are set.
-  const credentialsConfigured = !!config.clientId && !!config.clientSecret && config.profileId !== undefined;
+  const credentialsConfigured =
+    !!config.clientId && !!config.clientSecret && config.profileId !== undefined;
 
   const transportMode = config.http.transport;
   const runStdio = transportMode === 'stdio' || transportMode === 'both';

--- a/test/config-parsing.test.ts
+++ b/test/config-parsing.test.ts
@@ -99,4 +99,15 @@ describe('strict environment parsing', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('AVITO_MCP_WEBHOOK_ENABLED must be one of');
   });
+
+  it('documents approval and runtime-state settings in --help', () => {
+    const result = spawnSync(process.execPath, ['--import', 'tsx', 'src/server.ts', '--help'], {
+      cwd: resolve(import.meta.dirname, '..'),
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH, HOME: process.env.HOME },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('AVITO_MCP_APPROVAL_MODE');
+    expect(result.stdout).toContain('AVITO_MCP_RUNTIME_STATE_DIR');
+  });
 });

--- a/test/deploy-env.test.ts
+++ b/test/deploy-env.test.ts
@@ -17,16 +17,17 @@ async function render(base: string, remote: string) {
   const baseFile = join(cleanupRoot, 'base.env');
   const remoteFile = join(cleanupRoot, 'remote.env');
   const output = join(cleanupRoot, 'service.env');
+  const runtimeStateOutput = join(cleanupRoot, 'runtime-state-dir');
   await fs.writeFile(baseFile, base);
   await fs.writeFile(remoteFile, remote);
   const result = spawnSync(
     process.execPath,
-    [renderer, packageJson, baseFile, remoteFile, output],
+    [renderer, packageJson, baseFile, remoteFile, output, runtimeStateOutput],
     {
       encoding: 'utf8',
     },
   );
-  return { result, output };
+  return { result, output, runtimeStateOutput };
 }
 
 afterEach(async () => {
@@ -36,7 +37,7 @@ afterEach(async () => {
 
 describe('systemd deployment environment renderer', () => {
   it('parses dotenv syntax, allowlists runtime keys, and keeps remote overrides', async () => {
-    const { result, output } = await render(
+    const { result, output, runtimeStateOutput } = await render(
       'Client_id = "client id"\nClient_secret = "secret value"\nProfile_id = 123\nNPM_TOKEN=publish-canary\n',
       'AVITO_MCP_TRANSPORT = http\nAVITO_MCP_HTTP_HOST=0.0.0.0\nAVITO_MCP_HTTP_PORT=3456\nLOG_LEVEL=warn\nAVITO_TOKEN_FILE=/var/lib/avito-mcp/token.json\nAVITO_MCP_OAUTH_STORE_FILE=/var/lib/avito-mcp/oauth.json\nAVITO_MCP_WEBHOOK_LOG_FILE=/var/lib/avito-mcp/webhook.jsonl\nNPM_CONFIG_USERCONFIG=/secret/npmrc\n',
     );
@@ -56,6 +57,7 @@ describe('systemd deployment environment renderer', () => {
     });
     expect(raw).not.toContain('publish-canary');
     expect(raw).not.toContain('NPM_CONFIG_USERCONFIG');
+    expect(await fs.readFile(runtimeStateOutput, 'utf8')).toBe('/var/lib/avito-mcp/runtime\n');
     if (process.platform !== 'win32') expect((await fs.stat(output)).mode & 0o077).toBe(0);
 
     for (const [key, value] of [
@@ -75,6 +77,28 @@ describe('systemd deployment environment renderer', () => {
         `${key} must be an absolute file path inside /var/lib/avito-mcp`,
       );
     }
+  });
+
+  it('validates and resolves the configured runtime state directory', async () => {
+    const valid = await render(
+      'Client_id=id\nClient_secret=secret\nProfile_id=100\n',
+      'AVITO_MCP_RUNTIME_STATE_DIR=/var/lib/avito-mcp/shared-runtime\n',
+    );
+    expect(valid.result.status, valid.result.stderr).toBe(0);
+    expect(await fs.readFile(valid.runtimeStateOutput, 'utf8')).toBe(
+      '/var/lib/avito-mcp/shared-runtime\n',
+    );
+
+    await fs.rm(cleanupRoot!, { recursive: true, force: true });
+    cleanupRoot = undefined;
+    const invalid = await render(
+      'Client_id=id\nClient_secret=secret\nProfile_id=100\n',
+      'AVITO_MCP_RUNTIME_STATE_DIR=/tmp/outside-state\n',
+    );
+    expect(invalid.result.status).not.toBe(0);
+    expect(invalid.result.stderr).toContain(
+      'AVITO_MCP_RUNTIME_STATE_DIR must be an absolute directory at or inside /var/lib/avito-mcp',
+    );
   });
 
   it('fails closed instead of deploying without the full credential tuple', async () => {

--- a/test/http-hardening.test.ts
+++ b/test/http-hardening.test.ts
@@ -15,7 +15,7 @@
  *   - WebhookStore JSONL log: parent directory is created automatically.
  */
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { promises as fs } from 'node:fs';
@@ -519,7 +519,7 @@ describe('Streamable HTTP session contract + app surface', () => {
     expect(await response.json()).toEqual({ ok: true });
   });
 
-  it('/readyz fails closed for incomplete credentials or unusable token state', async () => {
+  it('/readyz fails closed for incomplete credentials or unusable durable state', async () => {
     const missing = await startRig({ clientSecret: '' });
     handle = missing.handle;
     expect((await fetch(`${missing.base}/readyz`)).status).toBe(503);
@@ -534,6 +534,18 @@ describe('Streamable HTTP session contract + app surface', () => {
       expect((await fetch(`${unusable.base}/readyz`)).status).toBe(503);
     } finally {
       await fs.rm(root, { force: true });
+    }
+
+    await handle?.close();
+    handle = undefined;
+    const runtimeRoot = join(tmpdir(), `http-unusable-runtime-${randomBytes(6).toString('hex')}`);
+    await fs.writeFile(runtimeRoot, 'not a directory');
+    try {
+      const unusable = await startRig({ runtimeStateDir: join(runtimeRoot, 'runtime') });
+      handle = unusable.handle;
+      expect((await fetch(`${unusable.base}/readyz`)).status).toBe(503);
+    } finally {
+      await fs.rm(runtimeRoot, { force: true });
     }
   });
 
@@ -729,7 +741,7 @@ describe('Streamable HTTP session contract + app surface', () => {
   });
 });
 
-describe('webhook config semantics (buildWebhookConfig via env)', () => {
+describe('environment-backed config semantics', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
@@ -745,6 +757,8 @@ describe('webhook config semantics (buildWebhookConfig via env)', () => {
       'AVITO_MCP_WEBHOOK_PATH',
       'AVITO_MCP_HTTP_MAX_SESSIONS',
       'AVITO_MCP_HTTP_SESSION_IDLE_SEC',
+      'AVITO_TOKEN_FILE',
+      'AVITO_MCP_RUNTIME_STATE_DIR',
     ]) {
       vi.stubEnv(k, '');
     }
@@ -790,6 +804,20 @@ describe('webhook config semantics (buildWebhookConfig via env)', () => {
     });
     expect(custom.http.maxSessions).toBe(7);
     expect(custom.http.sessionIdleSec).toBe(60);
+  });
+
+  it('derives runtime state beside the effective AVITO_TOKEN_FILE', async () => {
+    const tokenFile = join(tmpdir(), 'custom-avito-state', 'token.json');
+    const derived = await loadConfigWith({ AVITO_TOKEN_FILE: tokenFile });
+    expect(derived.tokenFile).toBe(tokenFile);
+    expect(derived.runtimeStateDir).toBe(join(dirname(tokenFile), 'runtime'));
+
+    const explicit = join(tmpdir(), 'explicit-avito-runtime');
+    const overridden = await loadConfigWith({
+      AVITO_TOKEN_FILE: tokenFile,
+      AVITO_MCP_RUNTIME_STATE_DIR: explicit,
+    });
+    expect(overridden.runtimeStateDir).toBe(explicit);
   });
 });
 


### PR DESCRIPTION
## What changed

- derive the default durable runtime-state directory from the effective `AVITO_TOKEN_FILE`
- make `/readyz` fail closed when the shared runtime-state directory is unavailable
- validate, create, and probe `AVITO_MCP_RUNTIME_STATE_DIR` as the `avito-mcp` service user during systemd installation
- document `AVITO_MCP_APPROVAL_MODE` and `AVITO_MCP_RUNTIME_STATE_DIR` in `--help`
- bump package and server metadata to 1.3.1 and add release notes

## Why

Version 1.3.0 derived runtime state from the platform default token path even when `AVITO_TOKEN_FILE` was overridden. That could split durable idempotency, pending approvals, and shared limiter state from the operator-selected state location. Deployment readiness also checked the token store but not this new shared state directory.

## Impact

Custom token paths now get a matching sibling `runtime` directory unless explicitly overridden. HTTP readiness and the installer fail closed before serving traffic when durable coordination state is inaccessible.

## Verification

- `npm run verify:release` — 338 tests across 31 files
- coverage: 80.95% statements, 71.91% branches, 81.86% functions, 83.83% lines
- `npm audit --audit-level=high` — 0 vulnerabilities
- targeted config, readiness, environment-renderer, and release-hardening tests
- `bash -n deploy/install-services.sh`
- `node --check deploy/render-service-env.mjs`
