### PR TITLE
fix: make persistent approval lockout atomic (v1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · Versioning: [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-07-17
+
+Security patch for durable hard-confirmation lockout across concurrent MCP processes. Existing tool names, schemas, and configuration remain unchanged. The release gate passes **352 tests across 31 files** with **81.37% statements / 72.72% branches / 83.24% functions / 84.23% lines** coverage.
+
+### Security
+
+- Failed `confirmation_secret` attempts are now counted in the durable pending-action record under a cross-process lock, so the five-attempt lockout survives process restarts and cannot be bypassed by opening a new stdio process.
+- Claim, cancellation, and final lockout are serialized per `confirmation_id`; exactly one terminal transition wins, and a stale process-local cache can no longer report a successful cancellation after another process already claimed the action.
+- A claimed action now remains durably fail-closed until execution and idempotency-result storage complete. Expired ledger entries cannot replay cancelled/locked actions or open a second confirmation while an earlier claim is unresolved.
+- Terminal pending-action removal is persisted with a directory `fsync`; persistent reads, listings, and lifecycle checks treat the shared state file as authoritative instead of reviving stale local entries.
+
+### Compatibility
+
+- Existing v1.3.0/v1.3.1 pending-action records remain readable because the new durable counter/state fields are optional. No migration or configuration change is required; upgrading is strongly recommended when `AVITO_MCP_CONFIRMATION_SECRET` is used.
+
 ## [1.3.1] - 2026-07-14
 
 Patch release for runtime-state placement and deployment readiness. The release gate passes **338 tests across 31 files** with **80.95% statements / 71.91% branches / 81.86% functions / 83.83% lines** coverage.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <a href="https://glama.ai/mcp/servers/elchin92/avito-mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/elchin92/avito-mcp/badges/card.svg" alt="avito-mcp MCP server" /></a>
 
-> **New in v1.3.1** — runtime state now follows a custom `AVITO_TOKEN_FILE`; `/readyz` and the systemd installer verify that shared durable state is accessible. See the [CHANGELOG](./CHANGELOG.md) for details.
+> **New in v1.3.2** — hard-confirmation lockout now survives restarts and is atomic across MCP processes; confirmation, cancellation, and final lockout cannot all claim the same pending action. See the [CHANGELOG](./CHANGELOG.md) for details.
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -19,7 +19,7 @@
 
 <a href="https://glama.ai/mcp/servers/elchin92/avito-mcp"><img width="380" height="200" src="https://glama.ai/mcp/servers/elchin92/avito-mcp/badges/card.svg" alt="avito-mcp MCP server" /></a>
 
-> **Новое в v1.3.1** — runtime state теперь следует за пользовательским `AVITO_TOKEN_FILE`; `/readyz` и systemd installer проверяют доступность общего durable state. Подробности — в [CHANGELOG](./CHANGELOG.md).
+> **Новое в v1.3.2** — блокировка hard-confirmation теперь переживает рестарт и атомарно работает между MCP-процессами; подтверждение, отмена и финальная блокировка не могут одновременно забрать одно pending action. Подробности — в [CHANGELOG](./CHANGELOG.md).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "avito-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "avito-mcp",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avito-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "mcpName": "io.github.elchin92/avito-mcp",
   "description": "Universal MCP server for the Avito API — 148 tools across 18 domains, safe-by-default with dry-run, durable idempotency, external approval, shared rate limits and structured errors. Runs over stdio or a reusable OAuth 2.1-secured HTTP backend, with a built-in Avito webhook receiver.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/elchin92/avito-mcp",
     "source": "github"
   },
-  "version": "1.3.1",
+  "version": "1.3.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "avito-mcp",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -11,16 +11,20 @@
  *   - On a repeated call with the same key but different args: ConflictError → the agent
  *     sees a clear error and does not get "the same result for different args"
  *
- * The design is intentionally in-memory. Persistent / shared backends (file, Redis, etc.)
- * are out of scope for a general-purpose package: different users will want different ones.
- * We document this as an extension point.
+ * Without stateDir/namespace the store is process-local. With them it uses
+ * locked, durable JSON records shared by stdio processes in the same namespace.
  */
 import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { withFileLock } from './file-lock.js';
-import { readJsonFile, safeStatePart, writeJsonAtomic } from './runtime-state.js';
+import {
+  readJsonFile,
+  removeFileDurable,
+  safeStatePart,
+  writeJsonAtomic,
+} from './runtime-state.js';
 
 export interface IdempotencyEntry {
   key: string;
@@ -57,6 +61,10 @@ export interface IdempotencyStoreOptions {
 export interface IdempotencyRetentionOptions {
   /** Keep an expired entry while an external lifecycle (for example confirmation) is active. */
   retainExpired?: (entry: IdempotencyEntry) => boolean;
+  /** Cross-process equivalent used before removing an expired durable record. */
+  retainExpiredPersistent?: (entry: IdempotencyEntry) => boolean | Promise<boolean>;
+  /** Fail closed unless a cached result is still safe and useful to replay. */
+  replayAllowed?: (entry: IdempotencyEntry) => boolean | Promise<boolean>;
 }
 
 export class IdempotencyConflictError extends Error {
@@ -198,15 +206,23 @@ export class IdempotencyStore {
           if (record && record.argsHash !== argsHash) {
             throw new IdempotencyConflictError(key, toolName);
           }
-          if (record?.state === 'completed' && record.result && record.expiresAt >= now) {
+          if (record?.state === 'completed' && record.result) {
             const entry = this.fromPersistent(record);
-            this.entries.set(this.composeKey(toolName, key), entry);
-            return { entry, replay: true };
+            const retained =
+              record.expiresAt >= now || (await this.isExpiredReplayRetained(entry, options));
+            if (retained && (await this.isReplayAllowed(entry, options))) {
+              this.entries.set(this.composeKey(toolName, key), entry);
+              return { entry, replay: true };
+            }
           }
           if (record?.state === 'in_flight') {
             throw new IdempotencyRecoveryRequiredError(key, toolName);
           }
-          if (record) await fs.rm(persistentPath, { force: true });
+          if (record) {
+            this.entries.delete(this.composeKey(toolName, key));
+            this.retainExpired.delete(this.composeKey(toolName, key));
+            await removeFileDurable(persistentPath);
+          }
 
           const reservation: PersistentRecord = {
             version: 1,
@@ -241,7 +257,11 @@ export class IdempotencyStore {
     const cached = this.entries.get(composed);
     if (cached) {
       if (cached.argsHash !== argsHash) throw new IdempotencyConflictError(key, toolName);
-      return { entry: cached, replay: true };
+      if (await this.isReplayAllowed(cached, options)) {
+        return { entry: cached, replay: true };
+      }
+      this.entries.delete(composed);
+      this.retainExpired.delete(composed);
     }
 
     const existing = this.reservations.get(composed);
@@ -322,6 +342,32 @@ export class IdempotencyStore {
       expiresAt: record.expiresAt,
       result: record.result!,
     };
+  }
+
+  private async isReplayAllowed(
+    entry: IdempotencyEntry,
+    options: IdempotencyRetentionOptions,
+  ): Promise<boolean> {
+    if (!options.replayAllowed) return true;
+    try {
+      return await options.replayAllowed(entry);
+    } catch {
+      // A lifecycle-check failure must never reopen a destructive slot.
+      return true;
+    }
+  }
+
+  private async isExpiredReplayRetained(
+    entry: IdempotencyEntry,
+    options: IdempotencyRetentionOptions,
+  ): Promise<boolean> {
+    if (!options.retainExpiredPersistent) return false;
+    try {
+      return await options.retainExpiredPersistent(entry);
+    } catch {
+      // An uncertain lifecycle must keep the destructive slot closed.
+      return true;
+    }
   }
 
   private cleanupExpired(): void {

--- a/src/core/pending-actions.ts
+++ b/src/core/pending-actions.ts
@@ -283,6 +283,17 @@ export class PendingActionStore {
     return { found: true, failedAttempts, locked };
   }
 
+  async recordFailedConfirmationPersistent(
+    id: string,
+    maxAttempts: number = 5,
+  ): Promise<ConfirmationFailureResult> {
+    const attempt = this.recordFailedConfirmation(id, maxAttempts);
+    if (attempt.locked) {
+      await this.deletePersistent(id);
+    }
+    return attempt;
+  }
+
   /** Clears the shared failure counter after a valid secret without deleting the action. */
   resetConfirmationFailures(id: string): void {
     this.failedConfirmationAttempts.delete(id);

--- a/src/core/pending-actions.ts
+++ b/src/core/pending-actions.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 
 import type { ToolRisk } from './tool-factory.js';
 import { withFileLock } from './file-lock.js';
-import { readJsonFile, writeJsonAtomic } from './runtime-state.js';
+import { readJsonFile, removeFileDurable, writeJsonAtomic } from './runtime-state.js';
 
 /**
  * Executor function for a pending action. Returned within the pending action
@@ -40,17 +40,13 @@ export interface PendingActionInfo {
 }
 
 /**
- * In-memory TTL'd store of pending actions awaiting confirmation.
+ * TTL'd store of pending actions awaiting confirmation. It can be process-local
+ * or backed by locked, durable records shared across stdio processes.
  *
- * Deliberately NOT persisted to disk:
- *   - after a restart the pending entries are lost, which is better than accidentally confirming a stale action
- *   - a stdio MCP server is usually ephemeral
- *   - smaller surface for leaks
+ * Confirmation is one-time: a durable claim is published before execution and
+ * removed only after the executor and result persistence succeed. Cancellation,
+ * expiry, and hard-confirmation lockout remove unclaimed entries.
  *
- * Confirmation is one-time: after a successful confirm the entry is removed.
- * Cancel and expiry remove it too. Cleanup is lazy — on every get/list.
- */
-/**
  * Subscriber for store changes. v0.6.0 — needed for the MCP resource
  * `avito://state/pending-actions`, so that clients can subscribe via
  * resources/subscribe and receive notifications/resources/updated.
@@ -94,13 +90,21 @@ export class PendingActionStore {
   private listeners: PendingChangeListener[] = [];
   private executors = new Map<
     string,
-    (args: Record<string, unknown>, idempotencyKey?: string, argsHash?: string) => Promise<CallToolResult>
+    (
+      args: Record<string, unknown>,
+      idempotencyKey?: string,
+      argsHash?: string,
+    ) => Promise<CallToolResult>
   >();
 
   constructor(
     private readonly ttlMs: number,
     private readonly maxActions: number = 1000,
-    private readonly persistent?: { stateDir: string; namespace: string; lockTimeoutMs?: number },
+    private readonly persistent?: {
+      stateDir: string;
+      namespace: string;
+      lockTimeoutMs?: number;
+    },
   ) {}
 
   registerExecutor(
@@ -146,7 +150,9 @@ export class PendingActionStore {
     return action;
   }
 
-  async createPersistent(input: Parameters<PendingActionStore['create']>[0]): Promise<PendingAction> {
+  async createPersistent(
+    input: Parameters<PendingActionStore['create']>[0],
+  ): Promise<PendingAction> {
     const action = this.create(input);
     const path = this.actionPath(action.id);
     if (path) {
@@ -169,12 +175,25 @@ export class PendingActionStore {
   }
 
   async getPersistent(id: string): Promise<PendingAction | undefined> {
-    const local = this.get(id);
-    if (local) return local;
     const path = this.actionPath(id);
-    if (!path) return undefined;
+    if (!path) return this.get(id);
+    this.cleanupExpired();
     const record = await readJsonFile<PersistentPendingRecord>(path);
-    return record ? this.rehydrate(record) : undefined;
+    if (!record) {
+      // The durable record is authoritative in persistent mode. Another
+      // process may have claimed, cancelled, expired, or locked the action.
+      this.delete(id);
+      return undefined;
+    }
+    if ((record.state ?? 'pending') !== 'pending') {
+      this.delete(id);
+      return undefined;
+    }
+    if (record.expiresAt < Date.now()) {
+      await this.removeExpiredPersistent(id, path);
+      return undefined;
+    }
+    return this.actions.get(id) ?? this.rehydrate(record);
   }
 
   /** Returns true if the entry existed and was removed, false if it never existed. */
@@ -187,15 +206,23 @@ export class PendingActionStore {
   }
 
   async deletePersistent(id: string): Promise<boolean> {
-    const local = this.delete(id);
     const path = this.actionPath(id);
-    if (!path) return local;
+    if (!path) return this.delete(id);
     return withFileLock(
       path,
       async () => {
-        const existed = (await readJsonFile<PersistentPendingRecord>(path)) !== undefined;
-        await fs.rm(path, { force: true });
-        return local || existed;
+        const record = await readJsonFile<PersistentPendingRecord>(path);
+        const existed =
+          record !== undefined &&
+          record.expiresAt >= Date.now() &&
+          (record.state ?? 'pending') === 'pending';
+        if (record && (record.state ?? 'pending') !== 'claimed') {
+          await removeFileDurable(path);
+        }
+        // A process-local entry may be stale after another process claimed or
+        // cancelled the action. Clear it, but never use it to report success.
+        this.delete(id);
+        return existed;
       },
       { timeoutMs: this.persistent?.lockTimeoutMs ?? 30_000 },
     );
@@ -227,16 +254,27 @@ export class PendingActionStore {
           this.actions.delete(id);
           return undefined;
         }
+        if ((record.state ?? 'pending') !== 'pending') {
+          this.delete(id);
+          return undefined;
+        }
         const local = this.actions.get(id);
         const action = local ?? this.rehydrate(record);
         if (!action || action.expiresAt < Date.now()) {
-          await fs.rm(path, { force: true });
+          await removeFileDurable(path);
+          this.delete(id);
           return undefined;
         }
+        // Publish the claimed state before returning the executor. Other
+        // processes must see that this id is executing, not cancelled.
+        await writeJsonAtomic(path, {
+          ...record,
+          state: 'claimed',
+          claimedAt: Date.now(),
+        });
         this.actions.delete(id);
         this.inFlight.set(id, action);
         this.failedConfirmationAttempts.delete(id);
-        await fs.rm(path, { force: true });
         this.emit('deleted', action);
         return action;
       },
@@ -252,6 +290,23 @@ export class PendingActionStore {
     return this.inFlight.delete(id);
   }
 
+  /** Removes the durable claimed marker only after execution/result persistence succeeds. */
+  async completePersistent(id: string): Promise<boolean> {
+    const completed = this.complete(id);
+    const path = this.actionPath(id);
+    if (!path || !completed) return completed;
+    return withFileLock(
+      path,
+      async () => {
+        const record = await readJsonFile<PersistentPendingRecord>(path);
+        if (!record || (record.state ?? 'pending') !== 'claimed') return false;
+        await removeFileDurable(path);
+        return true;
+      },
+      { timeoutMs: this.persistent?.lockTimeoutMs ?? 30_000 },
+    );
+  }
+
   /**
    * True while the action can still be confirmed OR is already executing. This
    * is intentionally wider than get(): confirmation callers must not be able to
@@ -260,6 +315,24 @@ export class PendingActionStore {
   isActive(id: string): boolean {
     this.cleanupExpired();
     return this.actions.has(id) || this.inFlight.has(id);
+  }
+
+  /** Durable lifecycle check for callers that may run in another process. */
+  async isActivePersistent(id: string): Promise<boolean> {
+    if (this.inFlight.has(id)) return true;
+    const path = this.actionPath(id);
+    if (!path) return this.isActive(id);
+    const record = await readJsonFile<PersistentPendingRecord>(path);
+    if (!record) {
+      this.delete(id);
+      return false;
+    }
+    if ((record.state ?? 'pending') === 'claimed') return true;
+    if (record.expiresAt < Date.now()) {
+      await this.removeExpiredPersistent(id, path);
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -283,15 +356,54 @@ export class PendingActionStore {
     return { found: true, failedAttempts, locked };
   }
 
+  /** Atomically shares the failure counter and final lockout across processes. */
   async recordFailedConfirmationPersistent(
     id: string,
     maxAttempts: number = 5,
   ): Promise<ConfirmationFailureResult> {
-    const attempt = this.recordFailedConfirmation(id, maxAttempts);
-    if (attempt.locked) {
-      await this.deletePersistent(id);
-    }
-    return attempt;
+    const path = this.actionPath(id);
+    if (!path) return this.recordFailedConfirmation(id, maxAttempts);
+
+    this.cleanupExpired();
+    return withFileLock(
+      path,
+      async () => {
+        const record = await readJsonFile<PersistentPendingRecord>(path);
+        if (!record) {
+          this.delete(id);
+          return { found: false, failedAttempts: 0, locked: false };
+        }
+        if ((record.state ?? 'pending') !== 'pending') {
+          this.delete(id);
+          return { found: false, failedAttempts: 0, locked: false };
+        }
+        if (record.expiresAt < Date.now()) {
+          if (record) await removeFileDurable(path);
+          // Another process may already have claimed, cancelled, or locked the
+          // durable action. Drop any stale process-local copy as well.
+          this.delete(id);
+          return { found: false, failedAttempts: 0, locked: false };
+        }
+        const previousFailures = record.failedConfirmationAttempts ?? 0;
+        if (!Number.isSafeInteger(previousFailures) || previousFailures < 0) {
+          throw new Error('Invalid persistent confirmation failure counter');
+        }
+        const failedAttempts = previousFailures + 1;
+        const locked = failedAttempts >= Math.max(1, maxAttempts);
+        if (locked) {
+          await removeFileDurable(path);
+          this.delete(id);
+        } else {
+          await writeJsonAtomic(path, {
+            ...record,
+            failedConfirmationAttempts: failedAttempts,
+          });
+          this.failedConfirmationAttempts.set(id, failedAttempts);
+        }
+        return { found: true, failedAttempts, locked };
+      },
+      { timeoutMs: this.persistent?.lockTimeoutMs ?? 30_000 },
+    );
   }
 
   /** Clears the shared failure counter after a valid secret without deleting the action. */
@@ -335,15 +447,36 @@ export class PendingActionStore {
     try {
       names = await fs.readdir(directory);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return this.list();
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
       throw error;
     }
     const records = await Promise.all(
-      names.filter((name) => /^[0-9a-f]{32}\.json$/.test(name)).map((name) => readJsonFile<PersistentPendingRecord>(join(directory, name))),
+      names
+        .filter((name) => /^[0-9a-f]{32}\.json$/.test(name))
+        .map(async (name) => ({
+          id: name.slice(0, -'.json'.length),
+          path: join(directory, name),
+          record: await readJsonFile<PersistentPendingRecord>(join(directory, name)),
+        })),
     );
-    const byId = new Map(this.list().map((item) => [item.id, item]));
-    for (const record of records) {
-      if (!record || record.expiresAt < Date.now()) continue;
+    // Durable records are authoritative in persistent mode. Process-local
+    // entries can be stale after another process claims, cancels, or locks one.
+    const byId = new Map<string, PendingActionInfo>();
+    const now = Date.now();
+    await Promise.all(
+      records
+        .filter(
+          ({ record }) =>
+            record !== undefined &&
+            (record.state ?? 'pending') === 'pending' &&
+            record.expiresAt < now,
+        )
+        .map(({ id, path }) => this.removeExpiredPersistent(id, path, now)),
+    );
+    for (const { record } of records) {
+      if (!record || record.expiresAt < now || (record.state ?? 'pending') !== 'pending') {
+        continue;
+      }
       byId.set(record.id, {
         id: record.id,
         toolName: record.toolName,
@@ -355,6 +488,45 @@ export class PendingActionStore {
       });
     }
     return [...byId.values()];
+  }
+
+  /** Finds a fail-closed claimed marker after its idempotency result replaced the pending payload. */
+  async hasClaimedPersistent(
+    toolName: string,
+    idempotencyKey: string,
+    argsHash: string,
+  ): Promise<boolean> {
+    for (const action of this.inFlight.values()) {
+      if (
+        action.toolName === toolName &&
+        action.idempotencyKey === idempotencyKey &&
+        action.argsHash === argsHash
+      ) {
+        return true;
+      }
+    }
+    if (!this.persistent) return false;
+    const directory = join(this.persistent.stateDir, this.persistent.namespace, 'pending');
+    let names: string[];
+    try {
+      names = await fs.readdir(directory);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      throw error;
+    }
+    const records = await Promise.all(
+      names
+        .filter((name) => /^[0-9a-f]{32}\.json$/.test(name))
+        .map((name) => readJsonFile<PersistentPendingRecord>(join(directory, name))),
+    );
+    return records.some(
+      (record) =>
+        record !== undefined &&
+        (record.state ?? 'pending') === 'claimed' &&
+        record.toolName === toolName &&
+        record.idempotencyKey === idempotencyKey &&
+        record.argsHash === argsHash,
+    );
   }
 
   /** For tests — the current size. */
@@ -397,6 +569,29 @@ export class PendingActionStore {
     return join(this.persistent.stateDir, this.persistent.namespace, 'pending', `${id}.json`);
   }
 
+  private async removeExpiredPersistent(
+    id: string,
+    path: string,
+    now: number = Date.now(),
+  ): Promise<boolean> {
+    return withFileLock(
+      path,
+      async () => {
+        const record = await readJsonFile<PersistentPendingRecord>(path);
+        if (!record) {
+          this.delete(id);
+          return false;
+        }
+        if ((record.state ?? 'pending') === 'claimed') return false;
+        if (record.expiresAt >= now) return false;
+        await removeFileDurable(path);
+        this.delete(id);
+        return true;
+      },
+      { timeoutMs: this.persistent?.lockTimeoutMs ?? 30_000 },
+    );
+  }
+
   private toRecord(action: PendingAction): PersistentPendingRecord {
     return {
       version: 1,
@@ -410,19 +605,31 @@ export class PendingActionStore {
       initiator: action.initiator,
       idempotencyKey: action.idempotencyKey,
       argsHash: action.argsHash,
+      state: 'pending',
     };
   }
 
   private rehydrate(record: PersistentPendingRecord): PendingAction | undefined {
-    if (record.version !== 1 || record.expiresAt < Date.now()) return undefined;
+    if (
+      record.version !== 1 ||
+      record.expiresAt < Date.now() ||
+      (record.state ?? 'pending') !== 'pending'
+    ) {
+      return undefined;
+    }
     const executor = this.executors.get(record.toolName);
     if (!executor) return undefined;
-    const action = { ...record } as Omit<PersistentPendingRecord, 'version'> & {
-      version?: number;
-    };
-    delete action.version;
     return {
-      ...action,
+      id: record.id,
+      toolName: record.toolName,
+      risk: record.risk,
+      summary: record.summary,
+      args: record.args,
+      createdAt: record.createdAt,
+      expiresAt: record.expiresAt,
+      initiator: record.initiator,
+      idempotencyKey: record.idempotencyKey,
+      argsHash: record.argsHash,
       execute: () => executor(record.args, record.idempotencyKey, record.argsHash),
     };
   }
@@ -430,6 +637,11 @@ export class PendingActionStore {
 
 interface PersistentPendingRecord extends Omit<PendingAction, 'execute'> {
   version: 1;
+  /** Missing means pending for backward compatibility with v1.3.0/v1.3.1. */
+  state?: 'pending' | 'claimed';
+  claimedAt?: number;
+  /** Shared hard-confirmation failures; optional for v1.3.0/1.3.1 records. */
+  failedConfirmationAttempts?: number;
 }
 
 export interface CallerExtra {

--- a/src/core/runtime-state.ts
+++ b/src/core/runtime-state.ts
@@ -67,14 +67,32 @@ export async function writeJsonAtomic(path: string, value: unknown): Promise<voi
   }
   try {
     await fs.rename(temp, path);
-    const dir = await fs.open(directory, 'r');
-    try {
-      await dir.sync();
-    } finally {
-      await dir.close();
-    }
+    await syncDirectory(directory);
   } catch (error) {
     await fs.rm(temp, { force: true }).catch(() => undefined);
     throw error;
+  }
+}
+
+/** Removes a runtime-state file and durably records the unlink in its directory. */
+export async function removeFileDurable(path: string): Promise<void> {
+  const directory = dirname(path);
+  await fs.rm(path, { force: true });
+  await syncDirectory(directory);
+}
+
+/** Flushes directory metadata where supported; some safe platforms reject directory fsync. */
+export async function syncDirectory(directory: string): Promise<void> {
+  let handle: import('node:fs/promises').FileHandle | undefined;
+  try {
+    handle = await fs.open(directory, 'r');
+    await handle.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'EINVAL' && code !== 'ENOTSUP' && code !== 'EPERM' && code !== 'EISDIR') {
+      throw error;
+    }
+  } finally {
+    await handle?.close().catch(() => undefined);
   }
 }

--- a/src/core/token-store.ts
+++ b/src/core/token-store.ts
@@ -4,6 +4,7 @@ import { createHash, randomBytes } from 'node:crypto';
 
 import { logger } from '../logger.js';
 import { withFileLock } from './file-lock.js';
+import { syncDirectory } from './runtime-state.js';
 
 export interface TokenRecord {
   version: 1;
@@ -251,21 +252,5 @@ export class TokenStore {
       await fs.rm(tmp, { force: true }).catch(() => undefined);
       logger.warn({ err, filePath: this.filePath }, 'failed to persist token to file');
     }
-  }
-}
-
-async function syncDirectory(directory: string): Promise<void> {
-  let handle: import('node:fs/promises').FileHandle | undefined;
-  try {
-    handle = await fs.open(directory, 'r');
-    await handle.sync();
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    // Directory fsync is unsupported on some otherwise safe platforms.
-    if (code !== 'EINVAL' && code !== 'ENOTSUP' && code !== 'EPERM' && code !== 'EISDIR') {
-      throw err;
-    }
-  } finally {
-    await handle?.close().catch(() => undefined);
   }
 }

--- a/src/core/tool-factory.ts
+++ b/src/core/tool-factory.ts
@@ -352,7 +352,10 @@ export function defineTool<I extends ZodRawShape>(
             sc?.requires_confirmation === true && typeof sc.confirmation_id === 'string'
               ? (sc.confirmation_id as string)
               : undefined;
-          if (stalePendingId !== undefined && !ctx.pendingStore.isActive(stalePendingId)) {
+          if (
+            stalePendingId !== undefined &&
+            !(await ctx.pendingStore.isActivePersistent(stalePendingId))
+          ) {
             ctx.idempotencyStore.delete(idempotencyKey, spec.name);
           } else {
             logger.info(
@@ -435,6 +438,32 @@ export function defineTool<I extends ZodRawShape>(
                     ? structured.confirmation_id
                     : undefined;
                 return confirmationId !== undefined && ctx.pendingStore.isActive(confirmationId);
+              },
+              retainExpiredPersistent: async (candidate) => {
+                const structured = candidate.result.structuredContent as
+                  Record<string, unknown> | undefined;
+                const confirmationId =
+                  structured?.requires_confirmation === true &&
+                  typeof structured.confirmation_id === 'string'
+                    ? structured.confirmation_id
+                    : undefined;
+                if (confirmationId !== undefined) {
+                  return ctx.pendingStore.isActivePersistent(confirmationId);
+                }
+                return ctx.pendingStore.hasClaimedPersistent(spec.name, idempotencyKey, argsHash);
+              },
+              replayAllowed: async (candidate) => {
+                const structured = candidate.result.structuredContent as
+                  Record<string, unknown> | undefined;
+                const confirmationId =
+                  structured?.requires_confirmation === true &&
+                  typeof structured.confirmation_id === 'string'
+                    ? structured.confirmation_id
+                    : undefined;
+                return (
+                  confirmationId === undefined ||
+                  (await ctx.pendingStore.isActivePersistent(confirmationId))
+                );
               },
             },
           );

--- a/src/domains/meta.ts
+++ b/src/domains/meta.ts
@@ -469,7 +469,7 @@ export const register: DomainRegister = (server, ctx) => {
           const provided =
             typeof args.confirmation_secret === 'string' ? args.confirmation_secret : '';
           if (!provided || !secretsMatch(provided, ctx.config.confirmationSecret!)) {
-            const attempt = ctx.pendingStore.recordFailedConfirmation(
+            const attempt = await ctx.pendingStore.recordFailedConfirmationPersistent(
               id,
               maxFailedConfirmationAttempts,
             );

--- a/src/domains/meta.ts
+++ b/src/domains/meta.ts
@@ -297,8 +297,14 @@ export const register: DomainRegister = (server, ctx) => {
       async (): Promise<CallToolResult> => {
         const manifest = readManifestMetadata();
         const tools = manifest.tools.map((value) => {
-          const tool = value as { name?: string; domain?: string; risk?: string; environment?: string };
-          const risk = (tool.risk ?? 'write') as 'read' | 'write' | 'money' | 'public' | 'sensitive';
+          const tool = value as {
+            name?: string;
+            domain?: string;
+            risk?: string;
+            environment?: string;
+          };
+          const risk = (tool.risk ?? 'write') as
+            'read' | 'write' | 'money' | 'public' | 'sensitive';
           return {
             name: tool.name ?? 'unknown',
             domain: tool.domain ?? 'unknown',
@@ -565,11 +571,15 @@ export const register: DomainRegister = (server, ctx) => {
         );
         try {
           // claimed.execute() records the final idempotency result before it
-          // resolves. Keep the claim active until then so the original tool call
-          // cannot treat its confirmation id as stale and create a second action.
-          return await claimed.execute();
-        } finally {
+          // resolves. Remove the durable claimed marker only after that succeeds.
+          const result = await claimed.execute();
+          await ctx.pendingStore.completePersistent(id);
+          return result;
+        } catch (error) {
+          // Keep the durable marker fail-closed when result persistence is unknown,
+          // but do not pin the process-local in-flight map forever.
           ctx.pendingStore.complete(id);
+          throw error;
         }
       },
     );

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -338,7 +338,7 @@ export function registerResources(server: McpServer, ctx: ToolContext): void {
         mimeType: 'application/json',
       },
       async (uri): Promise<ReadResourceResult> => {
-        const items = ctx.pendingStore.list();
+        const items = await ctx.pendingStore.listPersistent();
         return jsonResource(uri.toString(), {
           count: items.length,
           confirmation_mode: ctx.config.confirmationMode,

--- a/test/confirmation.test.ts
+++ b/test/confirmation.test.ts
@@ -77,6 +77,7 @@ async function makeRig(
   confirmationMode: ConfirmationMode,
   ttlSec = 900,
   extra: Partial<Config> = {},
+  persistent?: { stateDir: string; namespace: string },
 ) {
   const cfg = makeConfig({ confirmationMode, confirmationTtlSec: ttlSec, ...extra });
   const fetchMock = vi.fn(async (url: string) => {
@@ -95,8 +96,8 @@ async function makeRig(
   const client = new AvitoClient(cfg, {
     retry: { retry429BaseMs: 1, max429Retries: 0, retry5xxBackoffMs: 1, max5xxRetries: 0 },
   });
-  const pendingStore = new PendingActionStore(cfg.confirmationTtlSec * 1000);
-  const idempotencyStore = new IdempotencyStore(cfg.idempotencyTtlSec * 1000);
+  const pendingStore = new PendingActionStore(cfg.confirmationTtlSec * 1000, 1000, persistent);
+  const idempotencyStore = new IdempotencyStore(cfg.idempotencyTtlSec * 1000, 10_000, persistent);
   const ctx: ToolContext = { client, config: cfg, pendingStore, idempotencyStore };
 
   const server = new McpServer({ name: 'test', version: '0.0.0' });
@@ -360,6 +361,205 @@ describe('confirmation flow', () => {
     expect(rig.fetchMock.mock.calls.length).toBeGreaterThan(0);
     expect(rig.pendingStore.size()).toBe(0);
     await rig.client.close();
+  });
+
+  it('does not replay durable confirmation ids after cancellation or lockout', async () => {
+    const stateDir = await fs.mkdtemp(join(tmpdir(), 'avito-confirm-replay-'));
+    const persistent = { stateDir, namespace: 'account-a' };
+    const secret = 'persistent-lockout-secret-1234567890';
+    const argsAfterCancel = {
+      item_id: 1,
+      vas_id: 'cancelled',
+      idempotencyKey: 'persistent-cancel-key',
+    };
+    const argsAfterLockout = {
+      item_id: 2,
+      vas_id: 'locked',
+      idempotencyKey: 'persistent-lockout-key',
+    };
+    let firstRig: Awaited<ReturnType<typeof makeRig>> | undefined;
+    let restartedRig: Awaited<ReturnType<typeof makeRig>> | undefined;
+    const tokenFiles: string[] = [];
+    try {
+      firstRig = await makeRig('money_public', 900, { confirmationSecret: secret }, persistent);
+      cfg = firstRig.cfg;
+      tokenFiles.push(firstRig.cfg.tokenFile);
+      const cancelledPending = await firstRig.client.callTool({
+        name: 'money_tool',
+        arguments: argsAfterCancel,
+      });
+      const cancelledId = extractConfirmationId(parseText(cancelledPending.content));
+      await firstRig.client.callTool({
+        name: 'meta_cancel_action',
+        arguments: { confirmation_id: cancelledId },
+      });
+
+      const lockedPending = await firstRig.client.callTool({
+        name: 'money_tool',
+        arguments: argsAfterLockout,
+      });
+      const lockedId = extractConfirmationId(parseText(lockedPending.content));
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        await firstRig.client.callTool({
+          name: 'meta_confirm_action',
+          arguments: {
+            confirmation_id: lockedId,
+            confirmation_secret: `wrong-${attempt}`,
+          },
+        });
+      }
+      await firstRig.client.close();
+
+      restartedRig = await makeRig('money_public', 900, { confirmationSecret: secret }, persistent);
+      cfg = restartedRig.cfg;
+      tokenFiles.push(restartedRig.cfg.tokenFile);
+      const retriedCancelled = await restartedRig.client.callTool({
+        name: 'money_tool',
+        arguments: argsAfterCancel,
+      });
+      const retriedLocked = await restartedRig.client.callTool({
+        name: 'money_tool',
+        arguments: argsAfterLockout,
+      });
+
+      expect(extractConfirmationId(parseText(retriedCancelled.content))).not.toBe(cancelledId);
+      expect(extractConfirmationId(parseText(retriedLocked.content))).not.toBe(lockedId);
+      expect(retriedCancelled.structuredContent).not.toMatchObject({ idempotent_replay: true });
+      expect(retriedLocked.structuredContent).not.toMatchObject({ idempotent_replay: true });
+    } finally {
+      await firstRig?.client.close().catch(() => undefined);
+      await restartedRig?.client.close().catch(() => undefined);
+      await Promise.all(tokenFiles.map((file) => fs.rm(file, { force: true })));
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('retains an active persistent approval after the idempotency TTL expires', async () => {
+    let now = Date.now();
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const stateDir = await fs.mkdtemp(join(tmpdir(), 'avito-confirm-ledger-ttl-'));
+    const persistent = { stateDir, namespace: 'account-a' };
+    const args = {
+      item_id: 4,
+      vas_id: 'pending',
+      idempotencyKey: 'persistent-expired-ledger-key',
+    };
+    let firstRig: Awaited<ReturnType<typeof makeRig>> | undefined;
+    let restartedRig: Awaited<ReturnType<typeof makeRig>> | undefined;
+    const tokenFiles: string[] = [];
+    try {
+      firstRig = await makeRig('money_public', 900, { idempotencyTtlSec: 0.001 }, persistent);
+      cfg = firstRig.cfg;
+      tokenFiles.push(firstRig.cfg.tokenFile);
+      const first = await firstRig.client.callTool({ name: 'money_tool', arguments: args });
+      const confirmationId = extractConfirmationId(parseText(first.content));
+      await firstRig.client.close();
+
+      now += 2_000;
+      restartedRig = await makeRig('money_public', 900, { idempotencyTtlSec: 0.001 }, persistent);
+      cfg = restartedRig.cfg;
+      tokenFiles.push(restartedRig.cfg.tokenFile);
+      const retry = await restartedRig.client.callTool({ name: 'money_tool', arguments: args });
+
+      expect(extractConfirmationId(parseText(retry.content))).toBe(confirmationId);
+      expect(retry.structuredContent).toMatchObject({ idempotent_replay: true });
+      expect(await restartedRig.pendingStore.listPersistent()).toHaveLength(1);
+    } finally {
+      await firstRig?.client.close().catch(() => undefined);
+      await restartedRig?.client.close().catch(() => undefined);
+      await Promise.all(tokenFiles.map((file) => fs.rm(file, { force: true })));
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not reopen an idempotency slot while another process executes its claim', async () => {
+    let now = Date.now();
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const stateDir = await fs.mkdtemp(join(tmpdir(), 'avito-confirm-inflight-'));
+    const persistent = { stateDir, namespace: 'account-a' };
+    const secret = 'persistent-inflight-secret-123456789';
+    const args = {
+      item_id: 3,
+      vas_id: 'inflight',
+      idempotencyKey: 'persistent-inflight-key',
+    };
+    let firstRig: Awaited<ReturnType<typeof makeRig>> | undefined;
+    let restartedRig: Awaited<ReturnType<typeof makeRig>> | undefined;
+    let releaseOperation: (() => void) | undefined;
+    let confirmation: Promise<unknown> | undefined;
+    const tokenFiles: string[] = [];
+    try {
+      firstRig = await makeRig(
+        'money_public',
+        1,
+        { confirmationSecret: secret, idempotencyTtlSec: 0.001 },
+        persistent,
+      );
+      cfg = firstRig.cfg;
+      tokenFiles.push(firstRig.cfg.tokenFile);
+      const pending = await firstRig.client.callTool({ name: 'money_tool', arguments: args });
+      const confirmationId = extractConfirmationId(parseText(pending.content));
+
+      const operationGate = new Promise<void>((resolve) => {
+        releaseOperation = resolve;
+      });
+      let markOperationStarted!: () => void;
+      const operationStarted = new Promise<void>((resolve) => {
+        markOperationStarted = resolve;
+      });
+      firstRig.fetchMock.mockImplementation(async (url: string) => {
+        if (url.endsWith('/token')) {
+          return new Response(
+            JSON.stringify({ access_token: 'tk', expires_in: 3600, token_type: 'bearer' }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        markOperationStarted();
+        await operationGate;
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+
+      confirmation = firstRig.client.callTool({
+        name: 'meta_confirm_action',
+        arguments: { confirmation_id: confirmationId, confirmation_secret: secret },
+      });
+      await operationStarted;
+      now += 2_000;
+
+      restartedRig = await makeRig(
+        'money_public',
+        1,
+        { confirmationSecret: secret, idempotencyTtlSec: 0.001 },
+        persistent,
+      );
+      cfg = restartedRig.cfg;
+      tokenFiles.push(restartedRig.cfg.tokenFile);
+      const retry = await restartedRig.client.callTool({ name: 'money_tool', arguments: args });
+
+      expect(extractConfirmationId(parseText(retry.content))).toBe(confirmationId);
+      expect(retry.structuredContent).toMatchObject({ idempotent_replay: true });
+      expect(await restartedRig.pendingStore.listPersistent()).toEqual([]);
+      expect(restartedRig.fetchMock).not.toHaveBeenCalled();
+
+      releaseOperation?.();
+      releaseOperation = undefined;
+      await confirmation;
+      confirmation = undefined;
+
+      const completed = await restartedRig.client.callTool({ name: 'money_tool', arguments: args });
+      expect(parseText(completed.content)).not.toContain('requires_confirmation');
+      expect(completed.structuredContent).toMatchObject({ ok: true, idempotent_replay: true });
+    } finally {
+      releaseOperation?.();
+      await confirmation?.catch(() => undefined);
+      await firstRig?.client.close().catch(() => undefined);
+      await restartedRig?.client.close().catch(() => undefined);
+      await Promise.all(tokenFiles.map((file) => fs.rm(file, { force: true })));
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
   });
 
   it('write tool does NOT require confirmation in money_public mode', async () => {

--- a/test/pending-actions.test.ts
+++ b/test/pending-actions.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { randomBytes } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promises as fs } from 'node:fs';
 
 import { PendingActionLimitError, PendingActionStore } from '../src/core/pending-actions.js';
+
+const tempDirs: string[] = [];
+
+async function makeTempStateDir(): Promise<string> {
+  const directory = await fs.mkdtemp(
+    join(tmpdir(), `avito-pending-${randomBytes(6).toString('hex')}-`),
+  );
+  tempDirs.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
 
 const input = (name: string) => ({
   toolName: name,
@@ -78,6 +98,30 @@ describe('PendingActionStore shared confirmation lockout', () => {
     store.recordFailedConfirmation(action.id, 3);
     store.resetConfirmationFailures(action.id);
     expect(store.recordFailedConfirmation(action.id, 3).failedAttempts).toBe(1);
+  });
+
+  it('deletes persistent approvals when hard-confirmation failures lock out', async () => {
+    const stateDir = await makeTempStateDir();
+    const namespace = 'test-namespace';
+    const store = new PendingActionStore(60_000, 1000, { stateDir, namespace });
+    store.registerExecutor('protected', async () => ({ content: [] }));
+    const action = await store.createPersistent(input('protected'));
+    const actionFile = join(stateDir, namespace, 'pending', `${action.id}.json`);
+
+    expect(await fs.stat(actionFile)).toBeDefined();
+    expect(store.recordFailedConfirmation(action.id, 2)).toEqual({
+      found: true,
+      failedAttempts: 1,
+      locked: false,
+    });
+    expect(await store.recordFailedConfirmationPersistent(action.id, 2)).toEqual({
+      found: true,
+      failedAttempts: 2,
+      locked: true,
+    });
+
+    await expect(fs.stat(actionFile)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await store.getPersistent(action.id)).toBeUndefined();
   });
 });
 

--- a/test/pending-actions.test.ts
+++ b/test/pending-actions.test.ts
@@ -100,28 +100,207 @@ describe('PendingActionStore shared confirmation lockout', () => {
     expect(store.recordFailedConfirmation(action.id, 3).failedAttempts).toBe(1);
   });
 
-  it('deletes persistent approvals when hard-confirmation failures lock out', async () => {
+  it('shares persistent lockout failures across processes and restarts', async () => {
     const stateDir = await makeTempStateDir();
     const namespace = 'test-namespace';
-    const store = new PendingActionStore(60_000, 1000, { stateDir, namespace });
-    store.registerExecutor('protected', async () => ({ content: [] }));
-    const action = await store.createPersistent(input('protected'));
+    const persistent = { stateDir, namespace };
+    const creator = new PendingActionStore(60_000, 1000, persistent);
+    creator.registerExecutor('protected', async () => ({ content: [] }));
+    const action = await creator.createPersistent(input('protected'));
     const actionFile = join(stateDir, namespace, 'pending', `${action.id}.json`);
 
     expect(await fs.stat(actionFile)).toBeDefined();
-    expect(store.recordFailedConfirmation(action.id, 2)).toEqual({
+    expect(await creator.recordFailedConfirmationPersistent(action.id, 3)).toEqual({
       found: true,
       failedAttempts: 1,
       locked: false,
     });
-    expect(await store.recordFailedConfirmationPersistent(action.id, 2)).toEqual({
+
+    const secondProcess = new PendingActionStore(60_000, 1000, persistent);
+    secondProcess.registerExecutor('protected', async () => ({ content: [] }));
+    expect(await secondProcess.recordFailedConfirmationPersistent(action.id, 3)).toEqual({
       found: true,
       failedAttempts: 2,
+      locked: false,
+    });
+
+    const restartedProcess = new PendingActionStore(60_000, 1000, persistent);
+    restartedProcess.registerExecutor('protected', async () => ({ content: [] }));
+    expect(await restartedProcess.recordFailedConfirmationPersistent(action.id, 3)).toEqual({
+      found: true,
+      failedAttempts: 3,
       locked: true,
     });
 
     await expect(fs.stat(actionFile)).rejects.toMatchObject({ code: 'ENOENT' });
-    expect(await store.getPersistent(action.id)).toBeUndefined();
+    expect(await restartedProcess.getPersistent(action.id)).toBeUndefined();
+    expect(await creator.listPersistent()).not.toContainEqual(
+      expect.objectContaining({ id: action.id }),
+    );
+    expect(await creator.isActivePersistent(action.id)).toBe(false);
+    expect(await creator.getPersistent(action.id)).toBeUndefined();
+    expect(await creator.takePersistent(action.id)).toBeUndefined();
+  });
+
+  it('serializes concurrent persistent failures and locks exactly once', async () => {
+    const stateDir = await makeTempStateDir();
+    const namespace = 'failure-race-namespace';
+    const persistent = { stateDir, namespace };
+    const creator = new PendingActionStore(60_000, 1000, persistent);
+    const action = await creator.createPersistent(input('protected'));
+    const stores = Array.from(
+      { length: 3 },
+      () => new PendingActionStore(60_000, 1000, persistent),
+    );
+
+    const failures = await Promise.all(
+      stores.map((store) => store.recordFailedConfirmationPersistent(action.id, 3)),
+    );
+
+    expect(failures.filter((failure) => failure.locked)).toHaveLength(1);
+    expect(
+      failures
+        .filter((failure) => failure.found)
+        .map((failure) => failure.failedAttempts)
+        .sort((left, right) => left - right),
+    ).toEqual([1, 2, 3]);
+    expect(await creator.takePersistent(action.id)).toBeUndefined();
+  });
+
+  it('serializes final lockout with a concurrent persistent claim', async () => {
+    const stateDir = await makeTempStateDir();
+    const namespace = 'race-namespace';
+    const persistent = { stateDir, namespace };
+    const creator = new PendingActionStore(60_000, 1000, persistent);
+    creator.registerExecutor('protected', async () => ({ content: [] }));
+    const action = await creator.createPersistent(input('protected'));
+
+    expect(await creator.recordFailedConfirmationPersistent(action.id, 2)).toMatchObject({
+      failedAttempts: 1,
+      locked: false,
+    });
+
+    const failingProcess = new PendingActionStore(60_000, 1000, persistent);
+    const claimingProcess = new PendingActionStore(60_000, 1000, persistent);
+    claimingProcess.registerExecutor('protected', async () => ({ content: [] }));
+    const [failure, claim] = await Promise.all([
+      failingProcess.recordFailedConfirmationPersistent(action.id, 2),
+      claimingProcess.takePersistent(action.id),
+    ]);
+
+    expect(Number(failure.locked) + Number(claim !== undefined)).toBe(1);
+    expect(await claimingProcess.takePersistent(action.id)).toBeUndefined();
+  });
+
+  it('does not report cancellation after another process claimed the action', async () => {
+    const stateDir = await makeTempStateDir();
+    const namespace = 'cancel-after-claim-namespace';
+    const persistent = { stateDir, namespace };
+    const creator = new PendingActionStore(60_000, 1000, persistent);
+    const action = await creator.createPersistent(input('protected'));
+    const claimingProcess = new PendingActionStore(60_000, 1000, persistent);
+    claimingProcess.registerExecutor('protected', async () => ({ content: [] }));
+
+    expect(await claimingProcess.takePersistent(action.id)).toMatchObject({ id: action.id });
+    expect(await creator.deletePersistent(action.id)).toBe(false);
+    expect(await creator.getPersistent(action.id)).toBeUndefined();
+    expect(await creator.listPersistent()).toEqual([]);
+  });
+
+  it('lets exactly one of concurrent cancellation or claim win', async () => {
+    const stateDir = await makeTempStateDir();
+    const namespace = 'cancel-claim-race-namespace';
+    const persistent = { stateDir, namespace };
+    const cancellingProcess = new PendingActionStore(60_000, 1000, persistent);
+    const action = await cancellingProcess.createPersistent(input('protected'));
+    const claimingProcess = new PendingActionStore(60_000, 1000, persistent);
+    claimingProcess.registerExecutor('protected', async () => ({ content: [] }));
+
+    const [cancelled, claim] = await Promise.all([
+      cancellingProcess.deletePersistent(action.id),
+      claimingProcess.takePersistent(action.id),
+    ]);
+
+    expect(Number(cancelled) + Number(claim !== undefined)).toBe(1);
+    expect(await claimingProcess.takePersistent(action.id)).toBeUndefined();
+  });
+
+  it('lets only one process claim a persistent action', async () => {
+    const stateDir = await makeTempStateDir();
+    const namespace = 'claim-race-namespace';
+    const persistent = { stateDir, namespace };
+    const creator = new PendingActionStore(60_000, 1000, persistent);
+    const action = await creator.createPersistent(input('protected'));
+    const stores = Array.from(
+      { length: 2 },
+      () => new PendingActionStore(60_000, 1000, persistent),
+    );
+    for (const store of stores) {
+      store.registerExecutor('protected', async () => ({ content: [] }));
+    }
+
+    const claims = await Promise.all(stores.map((store) => store.takePersistent(action.id)));
+
+    expect(claims.filter((claim) => claim !== undefined)).toHaveLength(1);
+    expect(await creator.takePersistent(action.id)).toBeUndefined();
+  });
+
+  it('keeps a durable claimed marker until execution is completed', async () => {
+    const now = vi.spyOn(Date, 'now');
+    try {
+      now.mockReturnValue(1_000);
+      const stateDir = await makeTempStateDir();
+      const namespace = 'claimed-lifecycle-namespace';
+      const persistent = { stateDir, namespace };
+      const creator = new PendingActionStore(10, 1000, persistent);
+      const action = await creator.createPersistent({
+        ...input('protected'),
+        idempotencyKey: 'claimed-key',
+        argsHash: 'claimed-hash',
+      });
+      const claimingStore = new PendingActionStore(10, 1000, persistent);
+      claimingStore.registerExecutor('protected', async () => ({ content: [] }));
+      const observer = new PendingActionStore(10, 1000, persistent);
+
+      expect(await claimingStore.takePersistent(action.id)).toMatchObject({ id: action.id });
+      now.mockReturnValue(1_011);
+      expect(await observer.isActivePersistent(action.id)).toBe(true);
+      expect(await observer.getPersistent(action.id)).toBeUndefined();
+      expect(await observer.listPersistent()).toEqual([]);
+      expect(await observer.deletePersistent(action.id)).toBe(false);
+      expect(await observer.isActivePersistent(action.id)).toBe(true);
+      expect(await observer.hasClaimedPersistent('protected', 'claimed-key', 'claimed-hash')).toBe(
+        true,
+      );
+
+      expect(await claimingStore.completePersistent(action.id)).toBe(true);
+      expect(await observer.isActivePersistent(action.id)).toBe(false);
+      expect(await observer.hasClaimedPersistent('protected', 'claimed-key', 'claimed-hash')).toBe(
+        false,
+      );
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it('durably removes expired actions and does not report them as cancelled', async () => {
+    const now = vi.spyOn(Date, 'now');
+    try {
+      now.mockReturnValue(1_000);
+      const stateDir = await makeTempStateDir();
+      const namespace = 'expired-namespace';
+      const persistent = { stateDir, namespace };
+      const creator = new PendingActionStore(10, 1000, persistent);
+      const action = await creator.createPersistent(input('protected'));
+      const actionFile = join(stateDir, namespace, 'pending', `${action.id}.json`);
+
+      now.mockReturnValue(1_011);
+      expect(await creator.getPersistent(action.id)).toBeUndefined();
+      await expect(fs.stat(actionFile)).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(await creator.deletePersistent(action.id)).toBe(false);
+    } finally {
+      now.mockRestore();
+    }
   });
 });
 

--- a/test/reliability-1.3.test.ts
+++ b/test/reliability-1.3.test.ts
@@ -1,11 +1,13 @@
 import { mkdtemp, rm } from 'node:fs/promises';
+import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { IdempotencyStore } from '../src/core/idempotency.js';
 import { PendingActionStore } from '../src/core/pending-actions.js';
 import { RateLimiter } from '../src/core/rate-limiter.js';
+import { syncDirectory } from '../src/core/runtime-state.js';
 import { normalizeBbipResult } from '../src/domains/promotion.js';
 
 const directories: string[] = [];
@@ -17,7 +19,10 @@ async function stateDir(): Promise<string> {
 }
 
 afterEach(async () => {
-  await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  vi.restoreAllMocks();
+  await Promise.all(
+    directories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
 });
 
 describe('BBIP item-level outcome', () => {
@@ -43,6 +48,17 @@ describe('BBIP item-level outcome', () => {
 });
 
 describe('1.3 durable reliability state', () => {
+  it('tolerates platforms that do not support directory fsync', async () => {
+    const open = vi.spyOn(fs, 'open');
+    for (const code of ['EINVAL', 'ENOTSUP', 'EPERM', 'EISDIR']) {
+      open.mockRejectedValueOnce(Object.assign(new Error(code), { code }));
+      await expect(syncDirectory('/unused')).resolves.toBeUndefined();
+    }
+
+    open.mockRejectedValueOnce(Object.assign(new Error('I/O failure'), { code: 'EIO' }));
+    await expect(syncDirectory('/unused')).rejects.toMatchObject({ code: 'EIO' });
+  });
+
   it('replays a completed destructive result in a second process store', async () => {
     const directory = await stateDir();
     const options = { stateDir: directory, namespace: 'account-a' };
@@ -50,19 +66,75 @@ describe('1.3 durable reliability state', () => {
     const second = new IdempotencyStore(60_000, 100, options);
     let executions = 0;
 
-    const initial = await first.runExclusive('business-key', 'money_tool', 'same-args', async () => {
-      executions += 1;
-      return { content: [{ type: 'text', text: 'charged once' }] };
-    });
-    const replay = await second.runExclusive('business-key', 'money_tool', 'same-args', async () => {
-      executions += 1;
-      return { content: [{ type: 'text', text: 'must not run' }] };
-    });
+    const initial = await first.runExclusive(
+      'business-key',
+      'money_tool',
+      'same-args',
+      async () => {
+        executions += 1;
+        return { content: [{ type: 'text', text: 'charged once' }] };
+      },
+    );
+    const replay = await second.runExclusive(
+      'business-key',
+      'money_tool',
+      'same-args',
+      async () => {
+        executions += 1;
+        return { content: [{ type: 'text', text: 'must not run' }] };
+      },
+    );
 
     expect(initial.replay).toBe(false);
     expect(replay.replay).toBe(true);
     expect(replay.entry.result.content[0]).toMatchObject({ text: 'charged once' });
     expect(executions).toBe(1);
+  });
+
+  it('retains an expired final result while its durable claim is unreconciled', async () => {
+    let now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const directory = await stateDir();
+    const options = { stateDir: directory, namespace: 'account-a' };
+    const pendingCreator = new PendingActionStore(60_000, 100, options);
+    const pending = await pendingCreator.createPersistent({
+      toolName: 'money_tool',
+      risk: 'money',
+      summary: 'test',
+      args: {},
+      idempotencyKey: 'business-key',
+      argsHash: 'same-args',
+      execute: async () => ({ content: [] }),
+    });
+    const claimingStore = new PendingActionStore(60_000, 100, options);
+    claimingStore.registerExecutor('money_tool', async () => ({ content: [] }));
+    expect(await claimingStore.takePersistent(pending.id)).toBeDefined();
+
+    const first = new IdempotencyStore(10, 100, options);
+    await first.rememberPersistent('business-key', 'money_tool', 'same-args', {
+      content: [{ type: 'text', text: 'charged once' }],
+      structuredContent: { ok: true },
+    });
+    now = 1_011;
+    const second = new IdempotencyStore(10, 100, options);
+    let executions = 0;
+    const replay = await second.runExclusive(
+      'business-key',
+      'money_tool',
+      'same-args',
+      async () => {
+        executions += 1;
+        return { content: [{ type: 'text', text: 'must not run' }] };
+      },
+      {
+        retainExpiredPersistent: () =>
+          pendingCreator.hasClaimedPersistent('money_tool', 'business-key', 'same-args'),
+      },
+    );
+
+    expect(replay.replay).toBe(true);
+    expect(replay.entry.result.content[0]).toMatchObject({ text: 'charged once' });
+    expect(executions).toBe(0);
   });
 
   it('rehydrates and atomically claims a pending action in another store', async () => {

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -72,10 +72,13 @@ function makeConfig(): Config {
   };
 }
 
-async function makeRig(configure: (cfg: Config) => void = () => {}) {
+async function makeRig(
+  configure: (cfg: Config) => void = () => {},
+  persistent?: { stateDir: string; namespace: string },
+) {
   const cfg = makeConfig();
   configure(cfg);
-  const pendingStore = new PendingActionStore(cfg.confirmationTtlSec * 1000);
+  const pendingStore = new PendingActionStore(cfg.confirmationTtlSec * 1000, 1000, persistent);
   const webhookStore = new WebhookStore(cfg.webhook.bufferSize);
   const avito = new AvitoClient(cfg);
   const server = new McpServer(
@@ -212,6 +215,35 @@ describe('MCP resources — listing & static reads', () => {
     expect(body2.pending[0].risk).toBe('public');
     // args / execute did not leak:
     expect(body2.pending[0].args).toBeUndefined();
+  });
+
+  it('does not show an action claimed by another persistent store', async () => {
+    const stateDir = await fs.mkdtemp(join(tmpdir(), 'avito-resource-pending-'));
+    const persistent = { stateDir, namespace: 'account-a' };
+    const { client, ctx, cfg } = await makeRig(() => undefined, persistent);
+    cleanup = async () => {
+      await client.close();
+      await fs.rm(cfg.tokenFile, { force: true });
+      await fs.rm(stateDir, { recursive: true, force: true });
+    };
+    const action = await ctx.pendingStore.createPersistent({
+      toolName: 'items_update_price',
+      risk: 'public',
+      summary: 'test',
+      args: {},
+      execute: async () => ({ content: [{ type: 'text', text: 'local' }] }),
+    });
+    const claimingStore = new PendingActionStore(cfg.confirmationTtlSec * 1000, 1000, persistent);
+    claimingStore.registerExecutor('items_update_price', async () => ({
+      content: [{ type: 'text', text: 'claimed' }],
+    }));
+
+    expect(await claimingStore.takePersistent(action.id)).toMatchObject({ id: action.id });
+    const resource = await client.readResource({ uri: PENDING_ACTIONS_URI });
+    const body = JSON.parse((resource.contents[0] as { text: string }).text);
+
+    expect(body.count).toBe(0);
+    expect(body.pending).toEqual([]);
   });
 
   it('hides pending-actions resource when meta_list_pending_actions is denied', async () => {


### PR DESCRIPTION
### Motivation

The v1.3.1 hard-confirmation lockout was process-local: a restart or a second stdio process could reload the durable pending action and bypass the five-attempt limit. The original PR removed the file only after the local counter reached five, but the counter itself was still not shared and claim/cancel/expiry races remained.

### What changed

- Counts failed confirmation secrets inside the durable pending-action record under a cross-process file lock.
- Serializes lockout, cancellation, expiry, and one-time claim so exactly one transition wins.
- Persists a fail-closed `claimed` state before execution and removes it only after the final idempotency result is stored.
- Makes durable state authoritative for reads, listings, cancellation, and idempotency replay; stale confirmation IDs cannot be replayed or reopened after TTL expiry/restart.
- Durably syncs terminal file removal and reuses the common tolerant directory-sync helper.
- Bumps the patch release to `1.3.2`; tool names, schemas, and configuration are unchanged.

### Verification

- `npm run verify:release`
- 352 tests across 31 files
- Coverage: 81.37% statements, 72.72% branches, 83.24% functions, 84.23% lines
- Added restart and cross-process regressions for lockout, concurrent failures, claim/cancel races, expired records, claimed-state retention, and idempotency TTL interactions.
