### PR TITLE
test: drain background writers before removing their directory

### DIFF
--- a/test/http-hardening.test.ts
+++ b/test/http-hardening.test.ts
@@ -829,8 +829,10 @@ describe('WebhookStore JSONL durability', () => {
       const store = new WebhookStore(10, logFile);
       store.record({ id: 'e1', payload: { type: 'message', value: {} } });
 
-      // appendFile is fire-and-forget — give it a beat.
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // appendLog() is fire-and-forget. Sleeping only guesses at how long it takes, and
+      // an append that lands after the teardown rm() recreates the tree it just removed.
+      // flush() awaits the same queue the HTTP shutdown path does.
+      await store.flush();
       const written = await fs.readFile(logFile, 'utf8');
       expect(written).toContain('"e1"');
     } finally {

--- a/test/reliability-1.3.test.ts
+++ b/test/reliability-1.3.test.ts
@@ -1,7 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
 import { promises as fs } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { IdempotencyStore } from '../src/core/idempotency.js';
@@ -9,20 +6,25 @@ import { PendingActionStore } from '../src/core/pending-actions.js';
 import { RateLimiter } from '../src/core/rate-limiter.js';
 import { syncDirectory } from '../src/core/runtime-state.js';
 import { normalizeBbipResult } from '../src/domains/promotion.js';
+import { createSandbox, removeSandbox } from './support/sandbox.js';
 
 const directories: string[] = [];
 
+/**
+ * Every store below publishes its lease with mkdir and then has to recognise that
+ * directory again. os.tmpdir() is tmpfs on most hosts and never hands a freed inode
+ * back, so those ownership checks are untestable there; the repo filesystem is the one
+ * a deployment actually keeps its state on. Same reasoning as test/file-lock.test.ts.
+ */
 async function stateDir(): Promise<string> {
-  const path = await mkdtemp(join(tmpdir(), 'avito-mcp-1.3-'));
+  const path = await createSandbox('reliability-1.3');
   directories.push(path);
   return path;
 }
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(
-    directories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
-  );
+  await Promise.all(directories.splice(0).map((path) => removeSandbox(path)));
 });
 
 describe('BBIP item-level outcome', () => {
@@ -175,12 +177,14 @@ describe('1.3 durable reliability state', () => {
       'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 60),
     });
     first.observe('stats', headers);
+    // observe() is synchronous and only queues the write, so polling until the file
+    // appears proves nothing beyond the rename — the lease around it is still held, and
+    // releasing it renames the lease to a `<file>.lock.transitioned-<id>` sibling inside
+    // this very directory. A teardown rm() racing that sibling dies on ENOTEMPTY.
+    // flushPersisted() is the drain the server runs on shutdown: it returns once the
+    // snapshot is durable and the lease is gone, which is what the assertion needs.
+    await first.flushPersisted();
 
-    for (let attempt = 0; attempt < 20; attempt += 1) {
-      const shared = await second.getSharedStatus('stats');
-      if (shared.length > 0) break;
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
     expect(await second.getSharedStatus('stats')).toMatchObject([
       { domain: 'stats', limit: 10, remaining: 7 },
     ]);


### PR DESCRIPTION
## Symptom

CI on `main` is red, intermittently, on one case:

```
FAIL  test/reliability-1.3.test.ts > 1.3 durable reliability state >
      shares observed rate-limit state by account namespace
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/avito-mcp-1.3-5dMeZr/account-a/rate-limits'
```

Last failing run: https://github.com/elchin92/avito-mcp/actions/runs/30654515179 (`test (22.x)` and `test (24.x)`, 1 failed / 381 passed).

## Root cause

`RateLimiter.observe()` (`src/core/rate-limiter.ts`) is synchronous. It only puts the
snapshot in a queue via `persistLater()` and starts a `drain()` that nobody awaits.

The case polled `getSharedStatus()` until the snapshot file showed up. But the file
becomes visible at the `fs.rename()` inside `writeJsonAtomic()` (`src/core/runtime-state.ts`),
and that rename happens **while the lease is still held**. So the poll's `break` fired
with `syncDirectory()`, `sweepStaleTemps()` and the lease release still ahead of it.

Releasing the lease does `fs.rename(lockPath, transitionedPath)` (`src/core/file-lock.ts`),
which creates a `<file>.lock.transitioned-<hex>` sibling **inside the directory `afterEach`
is already removing**. That `rm()` runs with `maxRetries: 0`, so it hits the new entry and
dies with `ENOTEMPTY`.

Nothing in the assertion needed the poll. The poll is what opened the window.

## What changed

Test files only — `src/` is untouched.

- `test/reliability-1.3.test.ts`: `await first.flushPersisted()` replaces the poll loop.
  That is the same drain the server runs on shutdown; it returns once the snapshot is
  durable **and the lease is gone**, so the directory is quiet when teardown reaches it.
  `test/rate-limiter-persistence.test.ts` already drains after every `observe()` — this
  brings the one case that did not into line. The suite also moves onto
  `test/support/sandbox.ts`, putting its scratch directories on the repository filesystem
  like every other lease suite (precedent: 5862c45 "test: run every lease suite on the
  repository filesystem"), instead of tmpfs.
- `test/http-hardening.test.ts`: `WebhookStore.appendLog()` is fire-and-forget in exactly
  the same shape, and the JSONL durability case slept 100 ms instead of draining. An
  append landing after teardown recreates the tree that was just removed. It now awaits
  `store.flush()`, the queue the HTTP shutdown path awaits.

## Evidence

- Both affected suites, 30 consecutive runs under CPU + `dd oflag=dsync` load, on tmpfs:
  **30/30 green**. Same on ext4: **30/30 green**.
- Full suite twice: **33 files / 382 tests passing** both times.
- `npm run lint` clean, `npx tsc --noEmit` clean.
- `git diff --name-only` against `main` lists only the two test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
