### PR TITLE
chore: keep the research corpus out of the package and image (M0.5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,12 @@ coverage
 test
 swaggers/*.local.json
 
+# Research material for the protocol migration — never part of a runtime image.
+# The Dockerfile also copies docs/ file by file, so this is a second barrier.
+docs/mcp-2026-07-28
+MIGRATION_PLAN.md
+MIGRATION_PROGRESS.md
+
 # Secrets / local state — MUST never enter the image.
 .env*
 !.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,11 @@ deploy/Caddyfile.bak*
 # Test scratch directories (see test/support/sandbox.ts — they must live on the repo
 # filesystem, not on tmpfs, or the lease tests silently lose what they can detect)
 test/.sandbox/
+
+# Migration working set (M0.5): the 2026-07-28 spec corpus and the migration
+# notes are research inputs, not shippable sources. They stay untracked so they
+# can never reach git — and `files` in package.json plus .dockerignore keep them
+# out of the tarball and the image even while they sit in the working tree.
+docs/mcp-2026-07-28/
+MIGRATION_PLAN.md
+MIGRATION_PROGRESS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,13 +51,15 @@ ENV NODE_ENV=production \
     XDG_STATE_HOME=/home/node/.local/state
 
 # Runtime artifacts. node_modules + dist (incl. generated manifest.json) come from
-# the build stage; swaggers/ and docs/ are static and copied straight from context
-# (they back the MCP resources). package.json is read by version.ts.
+# the build stage; swaggers/ and docs/safety.md are static and copied straight from
+# the context (they back the MCP resources). docs/ is copied file by file on
+# purpose: a whole-directory COPY silently drags research material such as
+# docs/mcp-2026-07-28/ into the image. package.json is read by version.ts.
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/package.json ./package.json
 COPY swaggers ./swaggers
-COPY docs ./docs
+COPY docs/safety.md ./docs/safety.md
 COPY deploy/container-healthcheck.sh /usr/local/bin/avito-mcp-healthcheck
 
 RUN mkdir -p /home/node/.local/state/avito-mcp && \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/avito-mcp.svg)](https://www.npmjs.com/package/avito-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/avito-mcp.svg)](https://www.npmjs.com/package/avito-mcp)
 [![CI](https://github.com/elchin92/avito-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/elchin92/avito-mcp/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-382_passing-brightgreen)](./test)
+[![Tests](https://img.shields.io/badge/tests-383_passing-brightgreen)](./test)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](./tsconfig.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/node/v/avito-mcp.svg)](package.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/avito-mcp.svg)](https://www.npmjs.com/package/avito-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/avito-mcp.svg)](https://www.npmjs.com/package/avito-mcp)
 [![CI](https://github.com/elchin92/avito-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/elchin92/avito-mcp/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-382_passing-brightgreen)](./test)
+[![Tests](https://img.shields.io/badge/tests-383_passing-brightgreen)](./test)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](./tsconfig.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/node/v/avito-mcp.svg)](package.json)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "dist/server.js",
   "files": [
     "dist/",
-    "docs/",
+    "docs/safety.md",
     "swaggers/",
     "README.md",
     "README.ru.md",

--- a/test/release-hardening.test.ts
+++ b/test/release-hardening.test.ts
@@ -1,11 +1,76 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const root = resolve(import.meta.dirname, '..');
 const read = (path: string): string => readFileSync(resolve(root, path), 'utf8');
+
+/**
+ * Paths that must never reach the published tarball: the 2026-07-28 protocol
+ * corpus (8.4 MB of research material) and the migration notes. They are
+ * untracked by design, so the only thing standing between them and every npm
+ * consumer is the `files` allowlist — this gate proves the allowlist holds.
+ */
+const RESEARCH_DIR = 'docs/mcp-2026-07-28';
+const RESEARCH_ONLY_ROOT_FILES = ['MIGRATION_PLAN.md', 'MIGRATION_PROGRESS.md'];
+/** Everything under docs/ that is allowed to ship (docs/safety.md backs avito://docs/safety). */
+const PACKABLE_DOCS = new Set(['docs/safety.md']);
+
+/** Paths npm would put in the tarball, resolved without building or touching the network. */
+function packedFilePaths(cwd: string): string[] {
+  const stdout = execFileSync(
+    process.platform === 'win32' ? 'npm.cmd' : 'npm',
+    ['pack', '--dry-run', '--ignore-scripts', '--json'],
+    {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      maxBuffer: 32 * 1024 * 1024,
+    },
+  );
+  const json = stdout.slice(stdout.indexOf('['));
+  const packed = JSON.parse(json) as Array<{ files: Array<{ path: string }> } | undefined>;
+  const tarball = packed[0];
+  if (!tarball) throw new Error('npm pack --json reported no tarball');
+  return tarball.files.map((file) => file.path);
+}
+
+/**
+ * Packs this package.json against a planted research corpus, so the gate keeps
+ * proving something on a clean checkout — CI never has the corpus on disk.
+ * The decoys go into a scratch tree rather than the repository: writing them
+ * next to a running suite would churn inodes the lease tests depend on.
+ */
+function packedFilePathsAgainstDecoys(): string[] {
+  const temp = mkdtempSync(resolve(tmpdir(), 'avito-pack-gate-'));
+  try {
+    writeFileSync(resolve(temp, 'package.json'), read('package.json'));
+    const decoys = [
+      'docs/safety.md',
+      `${RESEARCH_DIR}/00-INDEX.md`,
+      `${RESEARCH_DIR}/spec-core.md`,
+      ...RESEARCH_ONLY_ROOT_FILES,
+    ];
+    for (const decoy of decoys) {
+      const path = resolve(temp, decoy);
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, '# pack gate decoy\n');
+    }
+    return packedFilePaths(temp);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
 
 function extractRunBlock(workflow: string, stepName: string): string {
   const marker = `      - name: ${stepName}\n`;
@@ -257,6 +322,54 @@ describe('release and deployment hardening', () => {
     },
     15_000,
   );
+
+  it('keeps the research corpus and migration notes out of the published package', () => {
+    const excluded = (paths: string[]): string[] =>
+      paths.filter(
+        (path) =>
+          path === RESEARCH_DIR ||
+          path.startsWith(`${RESEARCH_DIR}/`) ||
+          RESEARCH_ONLY_ROOT_FILES.includes(path),
+      );
+
+    // What this checkout would actually publish right now.
+    const packed = packedFilePaths(root);
+    // The resource body must still ship — excluding the corpus must not empty docs/.
+    expect(packed).toContain('docs/safety.md');
+    expect(excluded(packed)).toEqual([]);
+
+    // Any future docs/ subtree must be added to the allowlist deliberately,
+    // rather than riding along on a directory-wide entry.
+    const unexpectedDocs = packed.filter(
+      (path) => path.startsWith('docs/') && !PACKABLE_DOCS.has(path),
+    );
+    expect(unexpectedDocs).toEqual([]);
+
+    // Same packing contract, this time with the corpus present on disk: the gate
+    // must fail on a widened allowlist even when CI checks out a corpus-free tree.
+    const packedWithDecoys = packedFilePathsAgainstDecoys();
+    expect(packedWithDecoys).toContain('docs/safety.md');
+    expect(excluded(packedWithDecoys)).toEqual([]);
+
+    // Second barrier: the allowlist itself must name files under docs/, never the directory.
+    const pkg = JSON.parse(read('package.json')) as { files?: string[] };
+    expect(pkg.files).toBeDefined();
+    expect(pkg.files).toContain('docs/safety.md');
+    expect(pkg.files?.filter((entry) => /^docs\/?$/.test(entry))).toEqual([]);
+
+    // Third barrier: the same paths never enter the build context or the image.
+    const dockerignore = read('.dockerignore');
+    expect(dockerignore).toContain(RESEARCH_DIR);
+    for (const file of RESEARCH_ONLY_ROOT_FILES) expect(dockerignore).toContain(file);
+    const dockerfile = read('Dockerfile');
+    expect(dockerfile).toContain('COPY docs/safety.md ./docs/safety.md');
+    expect(dockerfile).not.toMatch(/^COPY docs \.\/docs$/m);
+
+    // Fourth barrier: the paths stay untracked, so they can never reach git either.
+    const gitignore = read('.gitignore');
+    expect(gitignore).toContain(`${RESEARCH_DIR}/`);
+    for (const file of RESEARCH_ONLY_ROOT_FILES) expect(gitignore).toContain(file);
+  }, 120_000);
 
   it('keeps the service installer executable', () => {
     expect(statSync(resolve(root, 'deploy/install-services.sh')).mode & 0o111).not.toBe(0);


### PR DESCRIPTION
## Why

`files` in `package.json` listed `docs/` as a whole directory and the Dockerfile ran `COPY docs ./docs`. The 2026-07-28 spec corpus in `docs/mcp-2026-07-28/` (66 files, 8.4 MB) is research material for the protocol migration, and nothing kept it out of a release: the next publish would have shipped it to every npm consumer and baked it into the runtime image. No existing gate would have caught it — the CI tarball check only looks for secrets and `dist/manifest.json`.

## Approach — three barriers, because no single one is sufficient

1. **`.gitignore`** — `docs/mcp-2026-07-28/`, `MIGRATION_PLAN.md`, `MIGRATION_PROGRESS.md` stay untracked for the whole migration. This keeps the corpus out of git, but `npm pack` builds from the working tree, so on its own it guarantees nothing about the tarball.
2. **Packing allowlist** — the `docs/` entry in `files` is narrowed to `docs/safety.md` rather than adding an `.npmignore`. Reasons: the allowlist already exists, so narrowing it is one deterministic mechanism instead of two interacting ones (an `.npmignore` next to a `files` allowlist makes the effective set harder to reason about); and `docs/safety.md` is the *only* file under `docs/` the runtime reads — it is the body of the `avito://docs/safety` resource (`src/resources.ts:44`). Naming files instead of a directory also flips the default: a future `docs/` subtree has to be added to the allowlist on purpose instead of silently riding along.
   *On `docs/adr/`*: `origin/main` currently has no `docs/adr/` (the ADR work is not merged). ADRs are repository governance records for contributors, not runtime inputs, and they are readable on GitHub — so they are deliberately **not** in the allowlist. If a later PR decides ADRs should ship, it adds the concrete paths and updates `PACKABLE_DOCS` in the gate; the gate fails loudly until it does, which is the intended behaviour.
3. **Image** — `COPY docs/safety.md ./docs/safety.md` replaces the directory copy, and `.dockerignore` excludes the same three paths from the build context.

## Gate

`test/release-hardening.test.ts` gains a case that checks the **actual** package composition, not just config:

- parses `npm pack --dry-run --ignore-scripts --json` in the repo and asserts `docs/safety.md` is present, that no `docs/mcp-2026-07-28/*`, `MIGRATION_PLAN.md` or `MIGRATION_PROGRESS.md` appear, and that nothing under `docs/` outside the allowlist ships;
- repeats the pack in a scratch tree with a planted corpus, so the gate still fails on a widened allowlist in CI, where the corpus never exists on disk. The decoys go to a temp directory rather than the repository on purpose: writing them next to a running suite churns inodes on the repo filesystem, and `test/file-lock.test.ts` depends on inode recycling (one such flake was observed while developing this and disappeared once the writes moved off the repo filesystem — 8/8 clean full-suite runs after).
- also pins the remaining barriers: no directory-wide `docs` entry in `files`, the `.dockerignore` entries, the by-name `COPY`, and the `.gitignore` entries.

No network, no build (`--ignore-scripts` skips `prepack`), ~1.2 s.

## Verification — line-by-line tarball diff

Baseline reproduced in the worktree with the corpus copied in: identical to the measurement taken in the main checkout (193 files / 2 839 070 B / 11 366 689 B unpacked).

| | before | after |
|---|---|---|
| files | 193 | 127 |
| packed | 2.84 MB | 480.4 kB |
| unpacked | 11.37 MB | 2.70 MB |

`diff` of the sorted file lists: **66 removals, 0 additions**. All 66 are `docs/mcp-2026-07-28/*` (65 documents + `00-INDEX.md`). `docs/safety.md` is still in the tarball; `dist/`, `swaggers/`, both READMEs, LICENSE, CHANGELOG, CONTRIBUTING, SECURITY, SUPPORT and `.env.example` are untouched.

Regression proof: with `files` reverted to `docs/` the new case fails — both with the corpus on disk (real pack) and on a corpus-free tree (planted pack), so the gate is not a tautology in CI.

`npm run lint`, `npx tsc --noEmit`, `npm run typecheck:tests`, `npm run typecheck:scripts` and `npm test` (383 passing, run on an ext4 worktree) are green.

Test-count badges bumped 382 -> 383 in both READMEs. Package version untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)