### PR TITLE
test: guard against reintroducing deprecated MCP surfaces (M0.4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,22 @@ One `defineTool(server, ctx, { ... })` call in the appropriate `src/domains/<nam
 - **Complex nested bodies** — model the bundled OpenAPI contract with explicit Zod schemas. Use `z.unknown()` only when the upstream schema is genuinely unconstrained, and document that exception in `test/openapi-contract.test.ts`.
 - **Custom execution still goes through `defineTool`** via `customExecute` / `buildDryRunPreview`. Do not register a business tool directly with `server.registerTool`: that bypasses the shared policy, confirmation, dry-run, idempotency, and error pipeline.
 
+## Deprecated MCP surfaces
+
+The MCP revision `2026-07-28` publishes a [registry of Deprecated features](https://modelcontextprotocol.io/specification/2026-07-28/deprecated). Four rows of it are features this server has never used — and **must not start using**. Each already has a published removal horizon and a migration path, so adopting one now means writing code with an expiry date.
+
+- **Sampling** — `sampling/createMessage`, `server.createMessage()`. Deprecated in `2026-07-28` (SEP-2577). Call an LLM provider directly; a server that needs an answer back from its caller uses the multi round-trip request pattern, not a server-initiated request.
+- **Roots** — `roots/list`, `listRoots()`, `notifications/roots/list_changed` (the notification is already removed, not just deprecated). Deprecated in `2026-07-28` (SEP-2577). Take directories and files as tool parameters, resource URIs, or configuration — `AVITO_MCP_ALLOWED_UPLOAD_DIRS` is exactly that.
+- **`includeContext: "thisServer"` / `"allServers"`** — deprecated by SEP-2596, removed no later than Sampling itself. Nothing to migrate: the field only exists on Sampling requests, which this server never sends.
+- **HTTP+SSE transport** — `SSEServerTransport`, `@modelcontextprotocol/sdk/*/sse.js`. Deprecated by SEP-2596 (soft-deprecated since `2025-03-26`). Use Streamable HTTP, already wired in `src/http/mcp-http.ts`.
+
+`test/deprecated-surface.test.ts` enforces this: it parses every `src/**/*.ts` with the TypeScript parser and fails on any of those identifiers, string literals or module specifiers. It looks at **code tokens only** — comments are trivia and are not scanned, so you can (and should) name a deprecated feature in a comment when explaining why it is absent.
+
+Two clarifications, since the registry is easy to misread:
+
+- Deprecated is not removed. Features already present in `src/` (Logging, Dynamic Client Registration) stay; the rule is only that no _new_ code path may depend on them. Widening their use is a review question, not an automatic no.
+- If an exception ever becomes genuinely necessary, change the rule list in `test/deprecated-surface.test.ts` in the same PR and state the reason — do not delete the test or skip the case.
+
 ## Tests
 
 - Unit tests (`vitest`) are required for anything in `src/core/`. Run: `npm test`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/avito-mcp.svg)](https://www.npmjs.com/package/avito-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/avito-mcp.svg)](https://www.npmjs.com/package/avito-mcp)
 [![CI](https://github.com/elchin92/avito-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/elchin92/avito-mcp/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-383_passing-brightgreen)](./test)
+[![Tests](https://img.shields.io/badge/tests-388_passing-brightgreen)](./test)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](./tsconfig.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/node/v/avito-mcp.svg)](package.json)

--- a/README.ru.md
+++ b/README.ru.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/avito-mcp.svg)](https://www.npmjs.com/package/avito-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/avito-mcp.svg)](https://www.npmjs.com/package/avito-mcp)
 [![CI](https://github.com/elchin92/avito-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/elchin92/avito-mcp/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-383_passing-brightgreen)](./test)
+[![Tests](https://img.shields.io/badge/tests-388_passing-brightgreen)](./test)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](./tsconfig.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/node/v/avito-mcp.svg)](package.json)

--- a/test/deprecated-surface.test.ts
+++ b/test/deprecated-surface.test.ts
@@ -1,0 +1,213 @@
+/**
+ * M0.4 — guard against reintroducing deprecated MCP surfaces.
+ *
+ * The MCP revision 2026-07-28 keeps a registry of Deprecated features:
+ * https://modelcontextprotocol.io/specification/2026-07-28/deprecated
+ *
+ * Four of its rows are things this server has never used, and must not start
+ * using while the migration is in flight: Roots, Sampling, the
+ * `includeContext` values "thisServer" / "allServers", and the HTTP+SSE
+ * transport. Adopting any of them now buys a feature with a known removal
+ * date and an already-published migration path.
+ *
+ * This test freezes that status quo: at the time it was written, every grep
+ * below was empty in `src/`.
+ *
+ * How it looks: the file is parsed with the TypeScript parser, and only
+ * *code* tokens are inspected — identifiers, string literals and template
+ * literal chunks. Comments are trivia and are deliberately NOT scanned, for
+ * two reasons: (1) the ban has to be explainable where it applies, and a
+ * guard that forbids writing "do not add sampling/createMessage here" in a
+ * comment would forbid documenting itself; (2) matching raw text would make
+ * the rule depend on prose, so a doc-comment quoting the spec would break the
+ * build while the actual wire surface stayed clean. Parsing instead of
+ * regexing the raw source also means a `//` inside a URL string cannot
+ * silently truncate a line and hide a real violation.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const REGISTRY = 'https://modelcontextprotocol.io/specification/2026-07-28/deprecated';
+
+interface Rule {
+  /** Registry row this rule protects. */
+  readonly feature: string;
+  /** What to do instead, per the registry's migration column. */
+  readonly migration: string;
+  /** Exact identifier names (the SDK-level spelling of the feature). */
+  readonly identifiers?: readonly string[];
+  /** String / template literals whose full text equals one of these. */
+  readonly literalEquals?: readonly string[];
+  /** String / template literals containing one of these (wire method names, module specifiers). */
+  readonly literalContains?: readonly string[];
+}
+
+const RULES: readonly Rule[] = [
+  {
+    feature: 'Sampling (`sampling/createMessage`) — Deprecated in 2026-07-28 by SEP-2577',
+    migration:
+      'integrate with an LLM provider directly; a server that needs something back from the caller uses the multi round-trip request pattern, not a server-initiated request',
+    identifiers: ['createMessage'],
+    literalContains: ['sampling/createMessage'],
+  },
+  {
+    feature: 'Roots (`roots/list`) — Deprecated in 2026-07-28 by SEP-2577',
+    migration:
+      'pass directories and files through tool parameters, resource URIs or server configuration (avito-mcp already does this via AVITO_MCP_ALLOWED_UPLOAD_DIRS)',
+    identifiers: ['listRoots'],
+    // Also catches `notifications/roots/list_changed`, which 2026-07-28 removed outright.
+    literalContains: ['roots/list'],
+  },
+  {
+    feature: '`includeContext: "thisServer" | "allServers"` — Deprecated by SEP-2596',
+    migration:
+      'omit the field or use "none" — but note the field only exists on Sampling requests, which this server does not send at all',
+    identifiers: ['includeContext'],
+    literalEquals: ['thisServer', 'allServers'],
+  },
+  {
+    feature: 'HTTP+SSE transport — Deprecated by SEP-2596 (soft-deprecated since 2025-03-26)',
+    migration:
+      'use the Streamable HTTP transport, which src/http/mcp-http.ts already uses (StreamableHTTPServerTransport)',
+    identifiers: ['SSEServerTransport'],
+    literalContains: ['server/sse.js', 'client/sse.js'],
+  },
+];
+
+interface Violation {
+  readonly file: string;
+  readonly line: number;
+  readonly token: string;
+  readonly rule: Rule;
+}
+
+/** Collect every `.ts` file under a directory, sorted for deterministic output. */
+function collectSources(dir: string, root: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) collectSources(full, root, out);
+    else if (entry.name.endsWith('.ts')) out.push(relative(root, full));
+  }
+  return out;
+}
+
+function matchRule(rule: Rule, kind: 'identifier' | 'literal', text: string): boolean {
+  if (kind === 'identifier') return (rule.identifiers ?? []).includes(text);
+  if ((rule.literalEquals ?? []).includes(text)) return true;
+  return (rule.literalContains ?? []).some((needle) => text.includes(needle));
+}
+
+/**
+ * Parse one source and report code tokens hitting a rule.
+ * Exported shape kept tiny on purpose: the scanner is itself under test below.
+ */
+function scanSource(file: string, source: string): Violation[] {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const found: Violation[] = [];
+
+  const visit = (node: ts.Node): void => {
+    const token: { kind: 'identifier' | 'literal'; text: string } | undefined =
+      ts.isIdentifier(node) || ts.isPrivateIdentifier(node)
+        ? { kind: 'identifier', text: node.text }
+        : ts.isStringLiteralLike(node) ||
+            ts.isTemplateHead(node) ||
+            ts.isTemplateMiddle(node) ||
+            ts.isTemplateTail(node)
+          ? { kind: 'literal', text: node.text }
+          : undefined;
+
+    if (token !== undefined) {
+      for (const rule of RULES) {
+        if (!matchRule(rule, token.kind, token.text)) continue;
+        const { line } = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile));
+        found.push({ file, line: line + 1, token: token.text, rule });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
+}
+
+/** One readable line per violation — this is what a failing diff shows. */
+const format = (v: Violation): string =>
+  `${v.file}:${v.line} uses "${v.token}" — ${v.rule.feature}`;
+
+function report(violations: readonly Violation[]): string {
+  return [
+    'Deprecated MCP surface reintroduced in src/:',
+    ...violations.map((v) => `  ${format(v)}\n      instead: ${v.rule.migration}`),
+    '',
+    `Deprecated registry: ${REGISTRY}`,
+    'Rule and rationale: CONTRIBUTING.md → "Deprecated MCP surfaces".',
+    'If a deliberate exception is ever needed, change the rule here in the same PR and say why.',
+  ].join('\n');
+}
+
+const root = resolve(import.meta.dirname, '..');
+const srcRoot = resolve(root, 'src');
+const sources = collectSources(srcRoot, root);
+
+describe('deprecated MCP surfaces (2026-07-28 registry)', () => {
+  it('scans the whole of src/', () => {
+    // A guard that silently scans nothing is worse than no guard.
+    expect(sources.length).toBeGreaterThan(30);
+    expect(sources).toContain('src/server.ts');
+    expect(sources).toContain('src/http/mcp-http.ts');
+    expect(sources).toContain('src/build-server.ts');
+  });
+
+  it('does not reference Roots, Sampling, deprecated includeContext values or HTTP+SSE', () => {
+    const violations = sources.flatMap((file) =>
+      scanSource(file, readFileSync(resolve(root, file), 'utf8')),
+    );
+    expect(violations.map(format), report(violations)).toEqual([]);
+  });
+
+  describe('the scanner itself', () => {
+    it('flags each forbidden surface in code', () => {
+      const cases: readonly [string, string][] = [
+        ['sampling', 'const r = await server.server.createMessage({ messages: [] });'],
+        ['sampling wire name', 'server.setRequestHandler("sampling/createMessage", handler);'],
+        ['roots', 'const r = await server.server.listRoots();'],
+        ['roots wire name', 'client.request({ method: "roots/list" });'],
+        ['includeContext field', 'const p = { includeContext: "none" };'],
+        ['includeContext value', 'const p = { fld: "thisServer" };'],
+        ['includeContext value', 'const p = { fld: "allServers" };'],
+        ['SSE transport', 'const t = new SSEServerTransport("/messages", res);'],
+        ['SSE module', 'import { X } from "@modelcontextprotocol/sdk/server/sse.js";'],
+        ['template literal', 'const m = `sampling/createMessage`;'],
+      ];
+      for (const [label, code] of cases) {
+        expect(scanSource('src/synthetic.ts', code), label).not.toEqual([]);
+      }
+    });
+
+    it('ignores mentions in comments, so the ban stays documentable', () => {
+      const commented = [
+        '// Never add sampling/createMessage or roots/list here.',
+        '/* listRoots and SSEServerTransport are deprecated; see the registry. */',
+        '/** includeContext: "thisServer" / "allServers" are deprecated values. */',
+        'export const ok = 1;',
+      ].join('\n');
+      expect(scanSource('src/synthetic.ts', commented)).toEqual([]);
+    });
+
+    it('does not fire on the filesystem-root vocabulary already used in src/', () => {
+      // upload-guard.ts talks about roots of the allowed upload directories.
+      const code = 'const expectedRootStat = await stat(allowedRoot); const roots = [allowedRoot];';
+      expect(scanSource('src/synthetic.ts', code)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `test/deprecated-surface.test.ts` — a guard that fails if `src/` starts using a feature the MCP `2026-07-28` [Deprecated registry](https://modelcontextprotocol.io/specification/2026-07-28/deprecated) lists, and records the rule in `CONTRIBUTING.md` (new section "Deprecated MCP surfaces").

Covered surfaces (all four have a published removal horizon and a migration path):

| Surface | Detected as |
| --- | --- |
| Sampling | identifier `createMessage`, literal containing `sampling/createMessage` |
| Roots | identifier `listRoots`, literal containing `roots/list` (also `notifications/roots/list_changed`) |
| `includeContext: "thisServer"` / `"allServers"` | identifier `includeContext`, literals `thisServer` / `allServers` |
| HTTP+SSE transport | identifier `SSEServerTransport`, module specifiers `*/server/sse.js`, `*/client/sse.js` |

This is a status-quo lock: every one of those greps is empty in `src/` today (confirmed before writing the test), so the PR changes no behaviour.

## How it looks

Each file is parsed with the TypeScript parser and only **code tokens** are inspected — identifiers, string literals, template chunks. Comments are trivia and are deliberately not scanned:

- the ban must be explainable where it applies; a guard that rejects `// do not add sampling/createMessage here` would forbid documenting itself;
- matching raw text would make the rule depend on prose — a doc-comment quoting the spec would break the build while the wire surface stayed clean;
- parsing also means a `//` inside a URL string cannot truncate a line and hide a real violation after it.

Bare `roots` / `sampling` identifiers are intentionally *not* flagged: `src/core/upload-guard.ts` legitimately talks about filesystem roots, and a false positive there would be a rename hazard, not a protocol regression.

The failure message names the file, line, token, the registry row and the migration, and points at `CONTRIBUTING.md`.

## Proof it actually fires

Injected a violation into a real source file in the worktree, then reverted:

```
### clean src/ (status quo)                    Tests  5 passed (5)

### `new SSEServerTransport(...)` in src/server.ts
  × does not reference Roots, Sampling, deprecated includeContext values or HTTP+SSE
  AssertionError: Deprecated MCP surface reintroduced in src/:
    src/server.ts:321 uses "SSEServerTransport" — HTTP+SSE transport — Deprecated by SEP-2596
        instead: use the Streamable HTTP transport, which src/http/mcp-http.ts already uses
                                               Tests  1 failed | 4 passed (5)

### same names, but only inside a comment      Tests  5 passed (5)
### reverted                                   Tests  5 passed (5)
```

The scanner is also covered by its own unit cases in the test file (one per forbidden surface, one comment-only case, one filesystem-root case).

## Checks

`npm run lint`, `npm run typecheck`, `npm run typecheck:tests`, `npm run typecheck:scripts` clean; `npm test` → **34 files / 388 tests passing** (run on ext4, +5 tests). Test-count badge in both READMEs refreshed 383 → 388.

Part of M0.4 of the 2026-07-28 migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)