### PR TITLE
Fix cancellation bypass of destructive idempotency

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -49,10 +49,9 @@ export interface RequestOptions {
    * stream is closed by the peer (revision 2026-07-28 defines exactly that as a
    * cancellation) or when a 2025 client sends `notifications/cancelled`.
    *
-   * Honouring it does three things the deadline timer cannot: it stops an
-   * in-flight Avito call the answer to which nobody can receive any more, it
-   * releases the rate-limiter slot this call reserved, and it unwedges the
-   * idempotency reservation (the ledger frees a lease on a thrown execute).
+   * Honouring it stops an in-flight Avito call whose answer nobody can receive.
+   * Once dispatch starts, rate and idempotency reservations remain consumed:
+   * Avito may already have accepted the request even if its response is lost.
    */
   signal?: AbortSignal;
 }
@@ -135,13 +134,15 @@ export class AvitoClient {
       reqInfo,
     );
 
+    let dispatched = false;
     try {
-      return await this.doRequest<T>(opts, url, reqInfo, deadline, rateKey);
+      return await this.doRequest<T>(opts, url, reqInfo, deadline, rateKey, () => {
+        dispatched = true;
+      });
     } catch (err) {
-      // Give the slot back ONLY on cancellation. Every other failure — a 4xx, a
-      // timeout, a transport error — still consumed a unit of the upstream
-      // budget, because the request did reach Avito.
-      if (opts.signal?.aborted === true) await slot.release();
+      // A cancellation before dispatch cannot have consumed upstream budget.
+      // After dispatch, fail closed because Avito may have received the request.
+      if (opts.signal?.aborted === true && !dispatched) await slot.release();
       throw err;
     }
   }
@@ -152,6 +153,7 @@ export class AvitoClient {
     reqInfo: RequestInfo,
     deadline: number,
     rateKey: string,
+    onDispatch: () => void,
   ): Promise<RequestResponse<T>> {
     let allowRefresh = true;
     let retries429 = 0;
@@ -176,6 +178,7 @@ export class AvitoClient {
           body: body as FetchBody | null,
           signal: fetchSignal,
         };
+        onDispatch();
         const resp =
           opts.method === 'GET' && body !== null
             ? await fetchGetWithBody(url, requestInit, opts.allowGetBody === true)

--- a/src/core/idempotency.ts
+++ b/src/core/idempotency.ts
@@ -37,7 +37,8 @@ export interface IdempotencyEntry {
 
 interface IdempotencyReservation {
   argsHash: string;
-  promise: Promise<IdempotencyEntry>;
+  promise?: Promise<IdempotencyEntry>;
+  uncertain?: boolean;
 }
 
 interface PersistentRecord {
@@ -65,6 +66,8 @@ export interface IdempotencyRetentionOptions {
   retainExpiredPersistent?: (entry: IdempotencyEntry) => boolean | Promise<boolean>;
   /** Fail closed unless a cached result is still safe and useful to replay. */
   replayAllowed?: (entry: IdempotencyEntry) => boolean | Promise<boolean>;
+  /** Keep the slot fail-closed when a rejected execution may have reached upstream. */
+  retainReservationOnError?: (error: unknown) => boolean;
 }
 
 export class IdempotencyConflictError extends Error {
@@ -241,9 +244,11 @@ export class IdempotencyStore {
             await writeJsonAtomic(persistentPath, this.toPersistent(entry));
             return { entry, replay: false };
           } catch (error) {
-            // A caught application failure means no usable result was produced. A hard
-            // process stop never reaches this branch, leaving the reservation fail-closed.
-            await fs.rm(persistentPath, { force: true });
+            // Cancellation after dispatch is ambiguous: upstream may have committed the
+            // mutation. Keep the durable in-flight marker until it is reconciled.
+            if (!options.retainReservationOnError?.(error)) {
+              await fs.rm(persistentPath, { force: true });
+            }
             throw error;
           }
         },
@@ -267,6 +272,9 @@ export class IdempotencyStore {
     const existing = this.reservations.get(composed);
     if (existing) {
       if (existing.argsHash !== argsHash) throw new IdempotencyConflictError(key, toolName);
+      if (existing.uncertain || !existing.promise) {
+        throw new IdempotencyRecoveryRequiredError(key, toolName);
+      }
       return { entry: await existing.promise, replay: true };
     }
 
@@ -285,7 +293,11 @@ export class IdempotencyStore {
         const result = await execute();
         resolveReservation(this.remember(key, toolName, argsHash, result, options));
       } catch (err) {
-        this.reservations.delete(composed);
+        if (options.retainReservationOnError?.(err)) {
+          this.reservations.set(composed, { argsHash, uncertain: true });
+        } else {
+          this.reservations.delete(composed);
+        }
         rejectReservation(err);
       }
     })();

--- a/src/core/rate-limiter.ts
+++ b/src/core/rate-limiter.ts
@@ -16,9 +16,9 @@ export interface RateSnapshot {
  * The outcome of {@link RateLimiter.waitIfNeeded}: the caller's claim on one
  * slot of the shared budget, and the way to give it back.
  *
- * M3 item 11 — "closing the response stream is a cancellation: the outgoing
- * Avito call is aborted, the idempotency lease and the rate-limiter slot are
- * released". The slot needs an explicit handle because the reservation is a
+ * A cancelled wait, or cancellation before an outbound request is dispatched,
+ * releases its rate-limiter slot. Once dispatch begins the slot remains spent,
+ * because Avito may already have accepted the request. The explicit handle is a
  * DURABLE side effect: `waitIfNeeded` decrements `remaining` in the shared
  * state file BEFORE the HTTP call, so that concurrent processes cannot both
  * spend the last unit. A caller that then never makes the call has burned a

--- a/src/core/tool-factory.ts
+++ b/src/core/tool-factory.ts
@@ -573,6 +573,12 @@ export function defineTool<I extends ZodRawShape>(
           spec.name,
           argsHash,
           () => execute(cleanArgs, signal),
+          {
+            // Once cancellation can race an outbound mutation, absence of a
+            // response is not proof that Avito did not commit it. Keep this key
+            // fail-closed until an operator reconciles the remote operation.
+            retainReservationOnError: () => signal?.aborted === true,
+          },
         );
         return replay ? annotateReplay(entry.result) : entry.result;
       } catch (err) {

--- a/test/idempotency.test.ts
+++ b/test/idempotency.test.ts
@@ -7,6 +7,7 @@ import {
   IdempotencyStore,
   IdempotencyConflictError,
   IdempotencyLimitError,
+  IdempotencyRecoveryRequiredError,
   hashArgs,
 } from '../src/core/idempotency.js';
 
@@ -208,5 +209,33 @@ describe('idempotency', () => {
     expect(store.size()).toBe(1);
     release();
     await first;
+  });
+
+  it('keeps an ambiguous failed mutation reserved instead of executing a retry', async () => {
+    const store = new IdempotencyStore(60_000);
+    const hash = hashArgs({ amount: 100 });
+    const cancellation = new Error('response stream closed after dispatch');
+    let executions = 0;
+
+    await expect(
+      store.runExclusive(
+        'charge-key',
+        'charge',
+        hash,
+        async () => {
+          executions += 1;
+          throw cancellation;
+        },
+        { retainReservationOnError: (error) => error === cancellation },
+      ),
+    ).rejects.toBe(cancellation);
+
+    await expect(
+      store.runExclusive('charge-key', 'charge', hash, async () => {
+        executions += 1;
+        return resultOf('charged twice');
+      }),
+    ).rejects.toBeInstanceOf(IdempotencyRecoveryRequiredError);
+    expect(executions).toBe(1);
   });
 });

--- a/test/modern-runtime.test.ts
+++ b/test/modern-runtime.test.ts
@@ -425,7 +425,7 @@ describe('A10 — request-scoped notifications/message', () => {
 // ───────────────────── 11. stream close is a cancellation ───────────────────
 
 describe('A11 — closing the response stream cancels the work', () => {
-  it('aborts the outgoing Avito call and frees the idempotency lease', async () => {
+  it('aborts the outgoing Avito call and keeps its idempotency lease fail-closed', async () => {
     // The fixture is a real HTTP exchange with a hung upstream: the token call
     // succeeds, the API call never answers. Nothing about the cancellation is
     // simulated — the client end of a real SSE response is closed, and the
@@ -490,9 +490,9 @@ describe('A11 — closing the response stream cancels the work', () => {
       stream.abort();
 
       await vi.waitFor(() => expect(apiSignal?.aborted).toBe(true), { timeout: 5_000 });
-      // Freed, not merely finished: a retry with the same key must be able to
-      // run rather than meet a wedged reservation.
-      await vi.waitFor(() => expect(rig.ctx.idempotencyStore!.size()).toBe(0), { timeout: 5_000 });
+      // Avito may have committed before its response was lost. The key must
+      // remain reserved so a retry cannot duplicate the mutation.
+      await vi.waitFor(() => expect(rig.ctx.idempotencyStore!.size()).toBe(1), { timeout: 5_000 });
     } finally {
       vi.unstubAllGlobals();
     }

--- a/test/reliability-1.3.test.ts
+++ b/test/reliability-1.3.test.ts
@@ -1,7 +1,10 @@
 import { promises as fs } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { IdempotencyStore } from '../src/core/idempotency.js';
+import {
+  IdempotencyRecoveryRequiredError,
+  IdempotencyStore,
+} from '../src/core/idempotency.js';
 import { PendingActionStore } from '../src/core/pending-actions.js';
 import { RateLimiter } from '../src/core/rate-limiter.js';
 import { syncDirectory } from '../src/core/runtime-state.js';
@@ -50,6 +53,36 @@ describe('BBIP item-level outcome', () => {
 });
 
 describe('1.3 durable reliability state', () => {
+  it('leaves ambiguous failures fail-closed in the durable ledger', async () => {
+    const directory = await stateDir();
+    const options = { stateDir: directory, namespace: 'account-a' };
+    const first = new IdempotencyStore(60_000, 100, options);
+    const second = new IdempotencyStore(60_000, 100, options);
+    const cancellation = new Error('cancelled after upstream dispatch');
+    let executions = 0;
+
+    await expect(
+      first.runExclusive(
+        'business-key',
+        'money_tool',
+        'same-args',
+        async () => {
+          executions += 1;
+          throw cancellation;
+        },
+        { retainReservationOnError: (error) => error === cancellation },
+      ),
+    ).rejects.toBe(cancellation);
+
+    await expect(
+      second.runExclusive('business-key', 'money_tool', 'same-args', async () => {
+        executions += 1;
+        return { content: [{ type: 'text', text: 'charged twice' }] };
+      }),
+    ).rejects.toBeInstanceOf(IdempotencyRecoveryRequiredError);
+    expect(executions).toBe(1);
+  });
+
   it('tolerates platforms that do not support directory fsync', async () => {
     const open = vi.spyOn(fs, 'open');
     for (const code of ['EINVAL', 'ENOTSUP', 'EPERM', 'EISDIR']) {


### PR DESCRIPTION
### Motivation

- Address a high-severity race where aborting an MCP request after the outbound `fetch()` may free rate-limit and idempotency reservations and permit duplicate destructive operations. 
- Make ambiguous cancellations (where the upstream may already have received the request) fail-closed so retries cannot re-run a possibly-committed mutation. 
- Preserve existing semantics for clear-cut cancellations that occur before dispatch so resources are still released promptly.

### Description

- Stop returning a rate-limiter slot when cancellation happens after dispatch by recording whether dispatch started and only releasing the slot if cancellation occurred before `fetch()` began (`src/core/client.ts`).
- Add a `retainReservationOnError` option to the idempotency retention options and make durable and in-memory stores keep reservations when errors indicate an ambiguous (possibly-committed) failure, marking them `uncertain` instead of deleting them (`src/core/idempotency.ts`).
- Wire `defineTool` to call `runExclusive(..., { retainReservationOnError: () => signal?.aborted === true })` for destructive idempotent calls so cancellations racing outbound mutations keep the ledger fail-closed (`src/core/tool-factory.ts`).
- Clarify rate-limiter documentation to reflect that slots released only for cancelled waits before dispatch, and leave slots spent once dispatch occurs (`src/core/rate-limiter.ts`).
- Update tests to cover process-local, durable, and real-modern-HTTP cancellation scenarios and assert that ambiguous cancellations do not permit duplicate execution (`test/idempotency.test.ts`, `test/reliability-1.3.test.ts`, `test/modern-runtime.test.ts`).

### Testing

- Ran static checks with `npm run typecheck` and `npm run typecheck:tests` and lint with `npm run lint`, which completed successfully. 
- Ran focused unit and integration tests with `npm test -- --run test/idempotency.test.ts test/reliability-1.3.test.ts test/modern-runtime.test.ts`, and all targeted tests passed (no failures).
- Verified the changed idempotency behaviors via new regression assertions that ambiguous cancellations leave reservations fail-closed and cause `IdempotencyRecoveryRequiredError` on subsequent retries.
- Verified there are no `git diff --check` issues and the working tree was left consistent after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ef480ee0c832480a466199cddabf2)