### PR TITLE
fix: prevent OAuth lease reclaim owner race

### DIFF
--- a/src/http/oauth/store.ts
+++ b/src/http/oauth/store.ts
@@ -812,27 +812,51 @@ export class OAuthStore {
     }
     if (Date.now() - newestMtimeMs <= LEASE_INITIALIZATION_GRACE_MS) return false;
 
-    // Everything above read a directory another process may be replacing. A lease
-    // published in the meantime carries a fresh mtime, so requiring it unchanged keeps
-    // the reclaim off a successor that took the path while we were looking.
+    // Publish a live transition marker before the final validation. This prevents an
+    // initializer from accepting a marker that it finishes while we validate: it must
+    // observe our competing marker in soleLeaseMarker(). Conversely, if it accepted just
+    // before our claim, the validation below observes its now-valid live owner marker.
+    const claimName = `.transition-${process.pid}-${OAuthStore.newId()}.json`;
+    const claimPath = join(leasePath, claimName);
     try {
-      const current = lstatSync(leasePath);
+      writeFileSync(claimPath, JSON.stringify({ pid: process.pid }), {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600,
+      });
+      this.beforeAbandonedLeaseValidation(leasePath);
+      const currentEntries = readdirSync(leasePath);
       if (
-        !current.isDirectory() ||
-        current.dev !== stat.dev ||
-        current.ino !== stat.ino ||
-        current.mtimeMs !== stat.mtimeMs
+        currentEntries.length !== entries.length + 1 ||
+        !currentEntries.includes(claimName) ||
+        entries.some((name) => !currentEntries.includes(name))
       ) {
+        rmSync(claimPath, { force: true });
+        return false;
+      }
+      for (const name of entries) {
+        const entryStat = lstatSync(join(leasePath, name));
+        const pid = this.leaseEntryOwnerPid(leasePath, name, entryStat);
+        if (pid !== undefined && processIsAlive(pid)) {
+          rmSync(claimPath, { force: true });
+          return false;
+        }
+      }
+
+      const current = lstatSync(leasePath);
+      if (!current.isDirectory() || current.dev !== stat.dev || current.ino !== stat.ino) {
+        rmSync(claimPath, { force: true });
         return false;
       }
     } catch {
+      rmSync(claimPath, { force: true });
       return false;
     }
 
     try {
       if (entries.length === 0) {
-        // rmdir refuses with ENOTEMPTY the instant a marker appears, so a generation that
-        // published while we looked survives even if it reused this very inode.
+        rmSync(claimPath, { force: true });
+        // rmdir refuses with ENOTEMPTY the instant another marker appears.
         rmdirSync(leasePath);
       } else {
         const movedPath = `${leasePath}.transitioned-${OAuthStore.newId()}`;
@@ -852,6 +876,10 @@ export class OAuthStore {
       'oauth store: reclaimed an abandoned lease',
     );
     return true;
+  }
+
+  private beforeAbandonedLeaseValidation(_leasePath: string): void {
+    // Tests override this no-op to complete a partial marker after the reclaim claim lands.
   }
 
   /** True when this marker identifies an owner, so inspectLease() can adjudicate it by pid. */

--- a/test/oauth-provider.test.ts
+++ b/test/oauth-provider.test.ts
@@ -1256,6 +1256,42 @@ describe('OAuthStore — durable serialized shutdown', () => {
     }
   });
 
+  it('does not reclaim a partial marker that becomes a live owner', async () => {
+    const { OAuthStore } = await import('../src/http/oauth/store.js');
+    const root = await createSandbox('oauth-partial-owner-race');
+    const storeFile = join(root, 'oauth.json');
+    const leasePath = `${storeFile}.process.lock`;
+    const markerPath = join(leasePath, 'owner-halfwritten.json');
+    const prototype = OAuthStore.prototype as unknown as {
+      beforeAbandonedLeaseValidation: (leasePath: string) => void;
+    };
+    const originalHook = prototype.beforeAbandonedLeaseValidation;
+    let intercepted = false;
+    try {
+      await fs.mkdir(leasePath, { recursive: true });
+      await fs.writeFile(markerPath, '', 'utf8');
+      const old = new Date(Date.now() - 120_000);
+      await fs.utimes(markerPath, old, old);
+      await fs.utimes(leasePath, old, old);
+      prototype.beforeAbandonedLeaseValidation = (observedPath) => {
+        if (intercepted || observedPath !== leasePath) return;
+        intercepted = true;
+        writeFileSync(markerPath, JSON.stringify({ pid: process.pid, id: 'halfwritten' }));
+      };
+
+      expect(() => new OAuthStore(storeFile)).toThrow(/already owned by active process/i);
+      expect(intercepted).toBe(true);
+      expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toEqual({
+        pid: process.pid,
+        id: 'halfwritten',
+      });
+      expect(readdirSync(leasePath)).toEqual(['owner-halfwritten.json']);
+    } finally {
+      prototype.beforeAbandonedLeaseValidation = originalHook;
+      await removeSandbox(root);
+    }
+  });
+
   it('refuses an unadjudicable lease whose transition marker names a live claimant', async () => {
     const root = await createSandbox('oauth-live-claimant');
     const storeFile = join(root, 'oauth.json');


### PR DESCRIPTION
### Motivation

- Prevent a TOCTOU race in OAuth lease reclamation where a zero-byte or partial owner marker could be completed into a live owner between the reclaim check and the destructive rename/remove, allowing reclamation to delete a live lease generation.

### Description

- Publish a uniquely-named live transition claim (`.transition-<pid>-<id>.json`) into the lease directory before the final validation to make reclamation observable to concurrent initializers.
- Revalidate the full entry set and owner PIDs after claiming, aborting and removing the claim if any entry became live or the directory contents changed, and only proceed with rename/remove when identity checks pass.
- Add a test hook `beforeAbandonedLeaseValidation` and a deterministic regression test that completes a partial marker while reclaim is in-flight to ensure the reclaim aborts in that race.
- Preserve existing empty/malformed-lease cleanup behavior while ensuring destructive operations only run after the claim and revalidation succeed.

### Testing

- `npx vitest run test/oauth-provider.test.ts` — all OAuth store tests passed (54/54) after the change.
- `npm run typecheck` — succeeded.
- `npm run typecheck:tests` — succeeded.
- `npm run lint` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a703c9ab6f08324b712846723286e0a)