### PR TITLE
chore(deps): stop Dependabot from reopening @types/node major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # @types/node is pinned to the oldest runtime we support (engines.node
+      # ">=22.12.0", CI matrix 22.x/24.x). A major bump would type-check code
+      # against APIs that do not exist on Node 22 — see commit 623d762, which
+      # deliberately downgraded ^25.9.2 -> ^22.20.1. Minor and patch updates
+      # inside the 22.x line stay enabled.
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why

`@types/node` is intentionally pinned to the **oldest runtime this package supports**, not to the newest available typings.

- `engines.node` is `">=22.12.0"`.
- The CI test matrix is `[22.x, 24.x]`.
- Commit [`623d762`](https://github.com/elchin92/avito-mcp/commit/623d76229c925b63ae70b831f70a5f770e3f0581) (audit remediation, v1.2.0) deliberately downgraded `@types/node` from `^25.9.2` to `^22.20.1` for exactly this reason.

Dependabot cannot know that, so it re-proposes the same major bump every week. It has now been opened and closed twice for the identical reason: #30 (`-> 26.1.1`) and #64 (`-> 26.1.2`). This PR removes the cause instead of closing the symptom again.

## Why a major bump is actually harmful here

The failure mode is silent — it does not show up as a red build, which is what makes it worth an explicit rule. Verified on `main` (`e6b65a1`) with this probe:

```ts
const p = new URLPattern({ pathname: "/items/:id" });
```

| `@types/node` | `tsc --noEmit` | Node 22.23.1 runtime |
| --- | --- | --- |
| `22.20.1` (current) | `error TS2304: Cannot find name 'URLPattern'` | `globalThis.URLPattern === undefined` |
| `26.1.2` (proposed) | compiles clean | `globalThis.URLPattern === undefined` |

With typings from Node 26, the compiler happily accepts APIs that do not exist on the minimum runtime we publish for. CI would stay green, and consumers installing from npm onto Node 22 would get a `ReferenceError` at runtime. The `22.x` typings are the guardrail that turns that class of mistake into a compile error.

## What this changes

One `ignore` entry on the npm update config:

```yaml
    ignore:
      - dependency-name: "@types/node"
        update-types:
          - "version-update:semver-major"
```

Deliberately narrow:

- **npm ecosystem only** — the `github-actions` update entry is untouched.
- **Exact `dependency-name`**, not a glob such as `@types/*`, so no other package is silenced.
- **Only `version-update:semver-major`** — minor and patch updates within the `22.x` line keep flowing through the existing `development-dependencies` group, so security and typing fixes still arrive.

When the minimum supported runtime is raised (bumping `engines.node` and the CI matrix), `@types/node` should be raised in the same commit and this rule revisited — that is a deliberate decision, not an automatic weekly PR.

## Note on labels

`.github/dependabot.yml` declares the labels `dependencies` and `ci`, but neither existed in the repository, so Dependabot was logging a label error on every run. Both labels have now been created; no config change was needed for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
