### PR TITLE
fix(deploy): refuse a deploy that moves the webhook receiver address

### DIFF
--- a/deploy/install-services.sh
+++ b/deploy/install-services.sh
@@ -59,6 +59,7 @@ for path in \
   "$SOURCE_ROOT/.remote.env" \
   "$SOURCE_ROOT/package.json" \
   "$SOURCE_ROOT/package-lock.json" \
+  "$SOURCE_ROOT/deploy/verify-webhook-secret.mjs" \
   "$SOURCE_ROOT/dist/server.js"; do
   if [[ ! -e "$path" ]]; then
     printf 'Required release file is missing: %s\n' "$path" >&2
@@ -318,6 +319,37 @@ if [[ ! -d "$release_dir" ]]; then
   mv "$STAGING_DIR" "$release_dir"
   STAGING_DIR=
 fi
+
+# The receiver's public URL is <public url><path>/<secret>, so re-rendering the
+# service environment from a checkout whose AVITO_MCP_WEBHOOK_SECRET is stale moves
+# that address out from under the live Avito subscription. Nothing downstream
+# notices: the receiver answers 200 to ANY secret on purpose (uniform response, so
+# the address cannot be probed), Avito therefore records every delivery as a success
+# and never unsubscribes, the service logs no error, and the access log skips the
+# receiver path. The only symptom is the event log quietly ceasing to grow. That is
+# exactly how 2026-09-07 lost 6 h 49 min of incoming messages: this installer put a
+# July secret back while the subscription still pointed at the August one.
+#
+# Checked BEFORE the transaction opens, so a refusal changes nothing at all. Exit
+# codes and the two opt-outs are documented in deploy/verify-webhook-secret.mjs.
+webhook_check_status=0
+node "$SOURCE_ROOT/deploy/verify-webhook-secret.mjs" \
+  "$release_dir/package.json" "$SOURCE_ROOT/.env" "$SOURCE_ROOT/.remote.env" \
+  "$SERVICE_ENV" || webhook_check_status=$?
+case $webhook_check_status in
+  0) ;;
+  4)
+    if [[ "${AVITO_MCP_DEPLOY_REQUIRE_SUBSCRIPTION_CHECK:-0}" == "1" ]]; then
+      printf 'Refusing to deploy: the live webhook subscription could not be verified\n' >&2
+      exit 1
+    fi
+    printf 'Warning: the live webhook subscription could not be verified; continuing\n' >&2
+    ;;
+  *)
+    printf 'Refusing to deploy: it would move the webhook receiver address\n' >&2
+    exit 1
+    ;;
+esac
 
 previous_release=
 if [[ -L "$CURRENT_LINK" ]]; then

--- a/deploy/verify-webhook-secret.mjs
+++ b/deploy/verify-webhook-secret.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+// Refuse a deploy that would silently move the webhook receiver's public address.
+//
+// The receiver's public URL is derived FROM the secret:
+//   <AVITO_MCP_WEBHOOK_PUBLIC_URL><AVITO_MCP_WEBHOOK_PATH>/<AVITO_MCP_WEBHOOK_SECRET>
+// (src/domains/webhook.ts, configuredWebhookReceiverUrl). install-services.sh
+// re-renders the entire service environment from the checkout on every deploy, so a
+// checkout whose AVITO_MCP_WEBHOOK_SECRET was not rotated together with the live
+// Avito subscription silently moves that address out from under the subscription.
+//
+// Nothing downstream notices. The receiver answers 200 to ANY secret on purpose
+// (src/http/webhook.ts, uniformOk: the address must not be discoverable by response
+// code or timing), so Avito keeps recording the delivery as successful and never
+// unsubscribes; the service logs no error; the access log skips the receiver path
+// (deploy/Caddyfile, log_skip). The only outward symptom is the webhook event log
+// quietly ceasing to grow. On 2026-09-07 that failure ran 6 h 49 min unnoticed.
+//
+// Two checks, in order of certainty:
+//   1. offline — rendered secret vs the secret the installed service currently runs
+//      with. A change here moves the public address; fatal unless declared.
+//   2. online  — rendered receiver URL vs the account's live subscriptions. This is
+//      the real invariant (Avito must deliver where we listen), but it needs the
+//      network, so being unable to answer only warns.
+//
+// Secrets never reach stdout/stderr: only lengths and 12-hex sha256 prefixes.
+//
+// Usage:  verify-webhook-secret.mjs <release-package.json> <base.env> <remote.env>
+//                                   [installed-service.env]
+// Exit:   0 ok · 2 usage · 3 mismatch (installer must abort) · 4 undetermined.
+
+import { createRequire } from 'node:module';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+const OK = 0;
+const USAGE = 2;
+const MISMATCH = 3;
+const UNDETERMINED = 4;
+const REQUEST_TIMEOUT_MS = Number(process.env.AVITO_MCP_DEPLOY_CHECK_TIMEOUT_MS || 8000);
+
+const [packageJson, baseEnv, remoteEnv, serviceEnv] = process.argv.slice(2);
+if (!packageJson || !baseEnv || !remoteEnv) {
+  process.stderr.write(
+    'Usage: verify-webhook-secret.mjs <release-package.json> <base.env> <remote.env> ' +
+      '[installed-service.env]\n',
+  );
+  process.exit(USAGE);
+}
+
+const say = (line) => process.stderr.write(`webhook-check: ${line}\n`);
+const flag = (name) => (process.env[name] ?? '').trim() === '1';
+const fingerprint = (value) => createHash('sha256').update(value).digest('hex').slice(0, 12);
+
+if (flag('AVITO_MCP_DEPLOY_SKIP_WEBHOOK_CHECK')) {
+  say('skipped by AVITO_MCP_DEPLOY_SKIP_WEBHOOK_CHECK=1');
+  process.exit(OK);
+}
+
+const require = createRequire(packageJson);
+const { parse } = require('dotenv');
+const readEnv = (file) => parse(readFileSync(file));
+
+// Same precedence as render-service-env.mjs: the remote overlay wins.
+const merged = { ...readEnv(baseEnv), ...readEnv(remoteEnv) };
+const nextSecret = (merged.AVITO_MCP_WEBHOOK_SECRET ?? '').trim();
+if (nextSecret === '') {
+  say('the checkout configures no webhook secret; receiver stays disabled, nothing to check');
+  process.exit(OK);
+}
+const nextPrint = fingerprint(nextSecret);
+
+// ─── 1. Offline: does this deploy change the address the service serves? ─────
+let installedSecret;
+if (serviceEnv) {
+  try {
+    installedSecret = (readEnv(serviceEnv).AVITO_MCP_WEBHOOK_SECRET ?? '').trim() || undefined;
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+}
+
+const rotationDeclared = flag('AVITO_MCP_DEPLOY_ALLOW_WEBHOOK_SECRET_CHANGE');
+if (installedSecret !== undefined && installedSecret !== nextSecret) {
+  say(
+    `the rendered webhook secret differs from the one the service is running with ` +
+      `(installed sha256=${fingerprint(installedSecret)} len=${installedSecret.length}, ` +
+      `checkout sha256=${nextPrint} len=${nextSecret.length})`,
+  );
+  say('the public receiver address is built from this secret, so this deploy moves it');
+  if (!rotationDeclared) {
+    say('refusing: rotate the checkout to the live secret, or declare an intentional rotation');
+    say('with AVITO_MCP_DEPLOY_ALLOW_WEBHOOK_SECRET_CHANGE=1 and re-subscribe right after');
+    process.exit(MISMATCH);
+  }
+  say('AVITO_MCP_DEPLOY_ALLOW_WEBHOOK_SECRET_CHANGE=1: treating it as an intentional rotation');
+  say('you MUST re-subscribe the new address at Avito, or deliveries stop silently');
+  process.exit(OK);
+}
+
+if (installedSecret === undefined) {
+  say('no installed service environment to compare against (first install)');
+} else {
+  say(`the deploy keeps the installed webhook secret (sha256=${nextPrint})`);
+}
+
+// ─── 2. Online: does Avito deliver where we will be listening? ───────────────
+if ((process.env.AVITO_MCP_DEPLOY_VERIFY_SUBSCRIPTION ?? '').trim() === '0') {
+  say('subscription check disabled by AVITO_MCP_DEPLOY_VERIFY_SUBSCRIPTION=0');
+  process.exit(OK);
+}
+
+const undetermined = (reason) => {
+  say(`could not verify the live subscription: ${reason}`);
+  process.exit(UNDETERMINED);
+};
+
+const stripTrailingSlash = (value) => value.replace(/\/+$/, '');
+const publicUrl = stripTrailingSlash(
+  (merged.AVITO_MCP_WEBHOOK_PUBLIC_URL ?? merged.AVITO_MCP_HTTP_PUBLIC_URL ?? '').trim(),
+);
+if (publicUrl === '') undetermined('no public URL is configured for the receiver');
+const rawPath = (merged.AVITO_MCP_WEBHOOK_PATH ?? '').trim() || '/avito/webhook';
+const path =
+  stripTrailingSlash(rawPath.startsWith('/') ? rawPath : `/${rawPath}`) || '/avito/webhook';
+const prefix = `${publicUrl}${path}/`;
+const expectedUrl = `${prefix}${encodeURIComponent(nextSecret)}`;
+
+const clientId = merged.Client_id ?? merged.CLIENT_ID;
+const clientSecret = merged.Client_secret ?? merged.CLIENT_SECRET;
+if (!clientId || !clientSecret) undetermined('the checkout carries no API credentials');
+const apiBase = stripTrailingSlash((merged.AVITO_BASE_URL ?? '').trim() || 'https://api.avito.ru');
+
+const post = async (url, init) => {
+  try {
+    return await fetch(url, { ...init, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+  } catch (error) {
+    undetermined(`${new URL(url).pathname} is unreachable (${error?.name || 'error'})`);
+    return undefined;
+  }
+};
+
+const tokenResponse = await post(`${apiBase}/token`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/x-www-form-urlencoded' },
+  body: new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: clientId,
+    client_secret: clientSecret,
+  }),
+});
+if (!tokenResponse.ok) undetermined(`/token answered ${tokenResponse.status}`);
+const token = (await tokenResponse.json().catch(() => ({})))?.access_token;
+if (typeof token !== 'string' || token === '') undetermined('/token returned no access_token');
+
+const subsResponse = await post(`${apiBase}/messenger/v1/subscriptions`, {
+  method: 'POST',
+  headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+  body: '{}',
+});
+if (!subsResponse.ok) undetermined(`/messenger/v1/subscriptions answered ${subsResponse.status}`);
+const subscriptions = (await subsResponse.json().catch(() => ({})))?.subscriptions;
+if (!Array.isArray(subscriptions)) undetermined('the subscription list could not be parsed');
+
+// Only subscriptions under OUR receiver base are ours to judge. The same account
+// legitimately carries other integrations' URLs on other hosts, and this check must
+// never comment on them, let alone fail a deploy because of them.
+const ours = subscriptions.filter(
+  (entry) => typeof entry?.url === 'string' && entry.url.startsWith(prefix),
+);
+if (ours.length === 0) {
+  undetermined(
+    `no subscription points at ${prefix}<secret> ` +
+      `(${subscriptions.length} subscription(s) on the account, all on other addresses)`,
+  );
+}
+if (ours.some((entry) => entry.url === expectedUrl)) {
+  say(`the live subscription matches the rendered address (secret sha256=${nextPrint})`);
+  process.exit(OK);
+}
+
+say(
+  `Avito delivers to ${prefix}<secret> with a DIFFERENT secret: ` +
+    ours
+      .map((entry) => `sha256=${fingerprint(decodeURIComponent(entry.url.slice(prefix.length)))}`)
+      .join(', ') +
+    `, this deploy would serve sha256=${nextPrint}`,
+);
+say('refusing: deliveries would be dropped silently (the receiver answers 200 to any secret)');
+process.exit(MISMATCH);

--- a/test/deploy-webhook-secret.test.ts
+++ b/test/deploy-webhook-secret.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { join, resolve } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { tmpdir } from 'node:os';
+
+const root = resolve(import.meta.dirname, '..');
+const checker = join(root, 'deploy', 'verify-webhook-secret.mjs');
+const packageJson = join(root, 'package.json');
+
+const LIVE_SECRET = 'f'.repeat(64);
+const STALE_SECRET = '1'.repeat(48);
+const PUBLIC_URL = 'https://mcp.example.test';
+const RECEIVER_PREFIX = `${PUBLIC_URL}/avito/webhook/`;
+
+let cleanupRoot: string | undefined;
+let api: Server | undefined;
+
+/**
+ * A stand-in for the Avito API. The checker must ask it for a token and for the
+ * account's subscription list; `subscribedSecret` decides which address that list
+ * claims Avito is delivering to.
+ */
+async function startApi(subscribedSecret: string | undefined) {
+  const server = createServer((request, response) => {
+    if (request.url === '/token') {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ access_token: 'test-token', expires_in: 86400 }));
+      return;
+    }
+    if (request.url === '/messenger/v1/subscriptions') {
+      // The account always carries a foreign integration's subscription too: the
+      // checker must judge only the URLs under our own receiver prefix.
+      const subscriptions = [{ url: 'https://other.example.test/callback.php', version: 'v3' }];
+      if (subscribedSecret !== undefined) {
+        subscriptions.push({ url: `${RECEIVER_PREFIX}${subscribedSecret}`, version: 'v3' });
+      }
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ subscriptions }));
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  await new Promise<void>((done) => server.listen(0, '127.0.0.1', done));
+  api = server;
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+async function run(options: {
+  checkoutSecret?: string;
+  installedSecret?: string | null;
+  subscribedSecret?: string | null;
+  env?: Record<string, string>;
+}) {
+  const apiBase = await startApi(
+    options.subscribedSecret === null ? undefined : (options.subscribedSecret ?? LIVE_SECRET),
+  );
+  cleanupRoot = join(tmpdir(), `avito-webhook-check-${randomBytes(6).toString('hex')}`);
+  await fs.mkdir(cleanupRoot, { recursive: true });
+  const baseFile = join(cleanupRoot, 'base.env');
+  const remoteFile = join(cleanupRoot, 'remote.env');
+  const serviceFile = join(cleanupRoot, 'service.env');
+  await fs.writeFile(baseFile, 'Client_id=id\nClient_secret=secret\nProfile_id=1\n');
+  const checkoutSecret = options.checkoutSecret ?? LIVE_SECRET;
+  await fs.writeFile(
+    remoteFile,
+    `AVITO_BASE_URL=${apiBase}\nAVITO_MCP_WEBHOOK_PUBLIC_URL=${PUBLIC_URL}\n` +
+      (checkoutSecret === '' ? '' : `AVITO_MCP_WEBHOOK_SECRET=${checkoutSecret}\n`),
+  );
+  if (options.installedSecret !== null) {
+    await fs.writeFile(
+      serviceFile,
+      `AVITO_MCP_WEBHOOK_SECRET="${options.installedSecret ?? LIVE_SECRET}"\n`,
+    );
+  }
+  // spawn, not spawnSync: the stub API above lives in THIS process's event loop,
+  // and a synchronous child would block it until the checker's own timeout fires.
+  return await new Promise<{ status: number | null; stderr: string }>((done) => {
+    const child = spawn(
+      process.execPath,
+      [checker, packageJson, baseFile, remoteFile, serviceFile],
+      {
+        env: { ...process.env, AVITO_MCP_DEPLOY_CHECK_TIMEOUT_MS: '4000', ...(options.env ?? {}) },
+      },
+    );
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('close', (status) => done({ status, stderr }));
+  });
+}
+
+afterEach(async () => {
+  if (api) await new Promise<void>((done) => api!.close(() => done()));
+  api = undefined;
+  if (cleanupRoot) await fs.rm(cleanupRoot, { recursive: true, force: true });
+  cleanupRoot = undefined;
+});
+
+describe('webhook secret deployment check', () => {
+  it('passes when the deploy keeps the address Avito already delivers to', async () => {
+    const result = await run({});
+    expect(result.stderr).toContain('the live subscription matches');
+    expect(result.status).toBe(0);
+  });
+
+  it('refuses a deploy that would move the receiver address, without printing secrets', async () => {
+    const result = await run({ checkoutSecret: STALE_SECRET });
+    expect(result.status).toBe(3);
+    expect(result.stderr).toContain('differs from the one the service is running with');
+    expect(result.stderr).not.toContain(STALE_SECRET);
+    expect(result.stderr).not.toContain(LIVE_SECRET);
+  });
+
+  it('refuses when the running service agrees but Avito delivers elsewhere', async () => {
+    // The 2026-09-07 shape once the bad env had already been installed: nothing on
+    // the host disagrees, and only the account's own subscription can tell.
+    const result = await run({ checkoutSecret: STALE_SECRET, installedSecret: STALE_SECRET });
+    expect(result.status).toBe(3);
+    expect(result.stderr).toContain('with a DIFFERENT secret');
+    expect(result.stderr).not.toContain(STALE_SECRET);
+  });
+
+  it('allows a declared rotation and demands a re-subscribe', async () => {
+    const result = await run({
+      checkoutSecret: STALE_SECRET,
+      env: { AVITO_MCP_DEPLOY_ALLOW_WEBHOOK_SECRET_CHANGE: '1' },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('re-subscribe');
+  });
+
+  it('only warns when no subscription points at this receiver', async () => {
+    const result = await run({ subscribedSecret: null });
+    expect(result.status).toBe(4);
+    expect(result.stderr).toContain('no subscription points at');
+  });
+
+  it('is a no-op when the checkout configures no receiver', async () => {
+    const result = await run({ checkoutSecret: '', installedSecret: null });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('nothing to check');
+  });
+
+  it('can be switched off entirely', async () => {
+    const result = await run({
+      checkoutSecret: STALE_SECRET,
+      env: { AVITO_MCP_DEPLOY_SKIP_WEBHOOK_CHECK: '1' },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('skipped by');
+  });
+});


### PR DESCRIPTION
## Why

On 2026-09-07 the Avito webhook receiver went silent for 6 h 49 min. Root cause: the
installer rebuilds the service environment from the checkout on every deploy, and the
checkout still carried a July `AVITO_MCP_WEBHOOK_SECRET`. The receiver URL is derived
from that secret, so the deploy silently moved the address Avito was subscribed to —
and yesterday's manual repair would not have survived the next deploy either.

## What this does

`deploy/install-services.sh` now calls `deploy/verify-webhook-secret.mjs` **before**
installing. The check compares the secret about to be installed against two independent
sources of truth:

1. the secret the running service is using;
2. the address Avito actually delivers to (live subscription lookup).

Any mismatch aborts the deploy without touching anything. No secret value is ever
printed — only whether it matched.

Escape hatches, all opt-in and documented in the script:
`AVITO_MCP_DEPLOY_ALLOW_WEBHOOK_SECRET_CHANGE` (intentional rotation),
`AVITO_MCP_DEPLOY_SKIP_WEBHOOK_CHECK`, `AVITO_MCP_DEPLOY_VERIFY_SUBSCRIPTION`,
`AVITO_MCP_DEPLOY_REQUIRE_SUBSCRIPTION_CHECK`, `AVITO_MCP_DEPLOY_CHECK_TIMEOUT_MS`.

## Tests

`test/deploy-webhook-secret.test.ts` — six scenarios against a local stub API, including
an exact replay of the 2026-09-07 incident (stale checkout secret + live subscription on
the old address → deploy refused).

## Provenance

The commit was authored and verified on the production host, where the repository has no
push credentials. It is carried here unchanged (`git bundle`), one commit on top of
`main`, and pushed from a workstation. Diff checked for secrets before pushing: test
fixtures only (`'f'.repeat(64)`, `'1'.repeat(48)`), no match with any live value.
